### PR TITLE
Fix EID KeyErrors

### DIFF
--- a/pybliometrics/scopus/scopus_search.py
+++ b/pybliometrics/scopus/scopus_search.py
@@ -84,7 +84,7 @@ class ScopusSearch(Search):
                 author_count=item.get('author-count', {}).get('$'),
                 affiliation_city=info.get("aff_city"), afid=info.get("afid"),
                 description=item.get('dc:description'), pii=item.get('pii'),
-                authkeywords=item.get('authkeywords'), eid=item['eid'],
+                authkeywords=item.get('authkeywords'), eid=item.get['eid'],
                 fund_acr=item.get('fund-acr'), pubmed_id=item.get('pubmed-id'))
             out.append(new)
         return out or None

--- a/pybliometrics/scopus/scopus_search.py
+++ b/pybliometrics/scopus/scopus_search.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from warnings import warn
 
 from pybliometrics.scopus.classes import Search
 from pybliometrics.scopus.utils import listify
@@ -68,7 +69,8 @@ class ScopusSearch(Search):
             try:
                 eid=item['eid']
             except KeyError:
-                pass
+                warn("KeyError: 'eID' missing in download. Filling in 'NA' now. Retry the download if you need the eID.")
+                item['eid']="NA"
             new = doc(article_number=item.get('article-number'),
                 title=item.get('dc:title'), fund_sponsor=item.get('fund-sponsor'),
                 subtype=item.get('subtype'), issn=item.get('prism:issn'),
@@ -88,7 +90,7 @@ class ScopusSearch(Search):
                 author_count=item.get('author-count', {}).get('$'),
                 affiliation_city=info.get("aff_city"), afid=info.get("afid"),
                 description=item.get('dc:description'), pii=item.get('pii'),
-                authkeywords=item.get('authkeywords'),
+                authkeywords=item.get('authkeywords'), eid=item['eid'],
                 fund_acr=item.get('fund-acr'), pubmed_id=item.get('pubmed-id'))
             out.append(new)
         return out or None

--- a/pybliometrics/scopus/scopus_search.py
+++ b/pybliometrics/scopus/scopus_search.py
@@ -65,6 +65,10 @@ class ScopusSearch(Search):
             date = item.get('prism:coverDate')
             if isinstance(date, list):
                 date = date[0].get('$')
+            try:
+                eid=item['eid']
+            except KeyError:
+                pass
             new = doc(article_number=item.get('article-number'),
                 title=item.get('dc:title'), fund_sponsor=item.get('fund-sponsor'),
                 subtype=item.get('subtype'), issn=item.get('prism:issn'),
@@ -84,7 +88,7 @@ class ScopusSearch(Search):
                 author_count=item.get('author-count', {}).get('$'),
                 affiliation_city=info.get("aff_city"), afid=info.get("afid"),
                 description=item.get('dc:description'), pii=item.get('pii'),
-                authkeywords=item.get('authkeywords'), eid=item.get['eid'],
+                authkeywords=item.get('authkeywords'),
                 fund_acr=item.get('fund-acr'), pubmed_id=item.get('pubmed-id'))
             out.append(new)
         return out or None


### PR DESCRIPTION
Here's an example where the `refresh`-based advice in #100 & [tips/KeyError.rst](https://github.com/pybliometrics-dev/pybliometrics/blob/master/docs/tips/KeyError.rst) helped me only after retrying more than 5 times:

```
s = robust_query('af-id(60015815) AND PUBYEAR > 2017')
df = pd.DataFrame(pd.DataFrame(s))
Traceback (most recent call last):
  File "C:\Users\...\AppData\Roaming\Python\Python37\site-packages\IPython\core\interactiveshell.py", line 3325, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-11-575f7f96be44>", line 1, in <module>
    df = pd.DataFrame(pd.DataFrame(s.results))
  File "C:\Users\...\AppData\Roaming\Python\Python37\site-packages\pybliometrics\scopus\scopus_search.py", line 87, in results
    authkeywords=item.get('authkeywords'), eid=item['eid'],
KeyError: 'eid'
```

I think the issue really results from [scopus_search.py#L68-L88](https://github.com/pybliometrics-dev/pybliometrics/blob/2983b48f8dc43931d8489233363850742fd0b2a8/pybliometrics/scopus/scopus_search.py#L68-L88) hard-coding the expected columns.

How about one of these commits to maybe avoid the error completely? Seems similar to the fix for #102.

As a user who doesn't need the eID at all, I don't really care whether Scopus is not sending it, or whether pybliometrics is demanding it.