### PR TITLE
Implement PlumX Metrics API

### DIFF
--- a/pybliometrics/scopus/__init__.py
+++ b/pybliometrics/scopus/__init__.py
@@ -5,6 +5,7 @@ from pybliometrics.scopus.abstract_retrieval import *
 from pybliometrics.scopus.affiliation_retrieval import *
 from pybliometrics.scopus.affiliation_search import *
 from pybliometrics.scopus.author_retrieval import *
+from pybliometrics.scopus.plumx_metrics import *
 from pybliometrics.scopus.author_search import *
 from pybliometrics.scopus.scopus_search import *
 from pybliometrics.scopus.serial_title import *

--- a/pybliometrics/scopus/abstract_retrieval.py
+++ b/pybliometrics/scopus/abstract_retrieval.py
@@ -551,12 +551,13 @@ class AbstractRetrieval(Retrieval):
 
     def __init__(self, identifier=None, refresh=False, view='META_ABS',
                  id_type=None):
-        """Interaction with the Abstract Retrieval API.
+        """Class to represent the results from retrieval request from the
+        Scopus Abstract API.
 
         Parameters
         ----------
         identifier : str or int
-            The identifier of a document.  Can be the Scoups EID, the Scopus
+            The identifier of a document.  Can be the Scopus EID, the Scopus
             ID, the PII, the Pubmed-ID or the DOI.
 
         refresh : bool or int (optional, default=False)

--- a/pybliometrics/scopus/abstract_retrieval.py
+++ b/pybliometrics/scopus/abstract_retrieval.py
@@ -551,8 +551,7 @@ class AbstractRetrieval(Retrieval):
 
     def __init__(self, identifier=None, refresh=False, view='META_ABS',
                  id_type=None):
-        """Class to represent the results from retrieval request from the
-        Scopus Abstract API.
+        """Interaction with the Abstract Retrieval API.
 
         Parameters
         ----------

--- a/pybliometrics/scopus/classes/retrieval.py
+++ b/pybliometrics/scopus/classes/retrieval.py
@@ -50,7 +50,7 @@ class Retrieval(Base):
 
         # Construct parameters
         url = RETRIEVAL_URL[api]
-        if api == "AbstractRetrieval" or api == "PlumXMetrics":
+        if api in ("AbstractRetrieval", "PlumXMetrics"):
             url += id_type + "/"
         params = {'view': view}
         if api == 'CitationOverview':

--- a/pybliometrics/scopus/classes/retrieval.py
+++ b/pybliometrics/scopus/classes/retrieval.py
@@ -50,7 +50,7 @@ class Retrieval(Base):
 
         # Construct parameters
         url = RETRIEVAL_URL[api]
-        if api == "AbstractRetrieval":
+        if api == "AbstractRetrieval" or api == "PlumXMetrics":
             url += id_type + "/"
         params = {'view': view}
         if api == 'CitationOverview':

--- a/pybliometrics/scopus/plumx_metrics.py
+++ b/pybliometrics/scopus/plumx_metrics.py
@@ -97,8 +97,7 @@ class PlumXMetrics(Retrieval):
         return _list_metrics_totals(usage_metrics) or None     
     
     def __init__(self, identifier, refresh=False):
-        """Class to represent the results from retrieval request from the
-        Scopus PlumX Metrics API.
+        """Interaction with the PlumX Metrics API.
 
         Parameters
         ----------
@@ -148,3 +147,4 @@ def _list_metrics_totals(metric_counts):
         new = capture(name=v[0], total=v[1])
         out.append(new)
     return out
+

--- a/pybliometrics/scopus/plumx_metrics.py
+++ b/pybliometrics/scopus/plumx_metrics.py
@@ -10,7 +10,8 @@ class PlumXMetrics(Retrieval):
         by PlumX Metrics in the form (capture, citation, mention, socialMedia,
         usage).
         Note: Can be empty. Specific categories can be absent depending on
-        existence of data and applicability of metrics to document type.
+        existence of data and applicability of metrics to document type. For 
+        Citation category a maximum citation count across sources is shown.
         For details on PlumX Metrics categories see
         https://plumanalytics.com/learn/about-metrics/
         """
@@ -49,8 +50,8 @@ class PlumXMetrics(Retrieval):
         """
         categories = self._json.get('count_categories', [])
         citation_metrics = _category_metrics('citation', categories)
+        source_metrics = []
         if citation_metrics:
-            source_metrics = []
             for item in citation_metrics:
                 if item.get('sources'):
                     source_metrics += item.get('sources')
@@ -109,12 +110,6 @@ class PlumXMetrics(Retrieval):
             is passed, cached file will be refreshed if the number of days
             since last modification exceeds that value.
 
-        Raises
-        ------
-        Scopus
-            If the id_type parameter or the view parameter contains
-            invalid entries.
-
         Notes
         -----
         The directory for cached results is `{path}/ENHANCED/{identifier}`,
@@ -144,6 +139,7 @@ def _list_metrics_totals(metric_counts):
     (name, total)
     """
     out = []
+    # Metric names and associated counts if either is not None
     values = [[m.get('name'), m.get('total')] for m in metric_counts
               if m.get('name') and m.get('total')]
     fields = 'name total'

--- a/pybliometrics/scopus/plumx_metrics.py
+++ b/pybliometrics/scopus/plumx_metrics.py
@@ -1,0 +1,154 @@
+from collections import namedtuple
+
+from pybliometrics.scopus.classes import Retrieval
+
+
+class PlumXMetrics(Retrieval):
+    @property
+    def category_totals(self):
+        """A list of namedtuples representing total metrics as categorized
+        by PlumX Metrics in the form (capture, citation, mention, socialMedia,
+        usage).
+        Note: Can be empty. Specific categories can be absent depending on
+        existence of data and applicability of metrics to document type.
+        For details on PlumX Metrics categories see
+        https://plumanalytics.com/learn/about-metrics/
+        """
+        out = []
+        fields = 'name total'
+        cat = namedtuple('Category', fields)
+        for item in self._json.get('count_categories', []):
+            if item.get('name') and item.get('total'):
+                new = cat(name=item.get('name'),
+                          total=item.get('total'))
+                out.append(new)
+        return out or None
+    
+    @property
+    def capture(self):
+        """A list of namedtuples representing metrics in Captures category:
+        metrics that track when end users bookmark, favorite, become a reader,
+        become a watcher, etc, i.e. metrics that indicate that someone wants
+        to come back to the work.
+        Note: Can be empty. Specific metrics can be absent depending on
+        existence of data and applicability of metrics to document type.
+        For details on Capture metrics see
+        https://plumanalytics.com/learn/about-metrics/capture-metrics/
+        """
+        categories = self._json.get('count_categories', [])
+        mention_metrics = _category_metrics('capture', categories)
+        return _list_metrics_totals(mention_metrics) or None   
+    
+    @property
+    def citation(self):
+        """A list of namedtuples representing citation counts from 
+        different sources.
+        Note: Can be empty.
+        For details and list of possible sources see
+        https://plumanalytics.com/learn/about-metrics/citation-metrics/
+        """
+        categories = self._json.get('count_categories', [])
+        citation_metrics = _category_metrics('citation', categories)
+        if citation_metrics:
+            source_metrics = []
+            for item in citation_metrics:
+                if item.get('sources'):
+                    source_metrics += item.get('sources')
+        return _list_metrics_totals(source_metrics) or None
+    
+    @property
+    def mention(self):
+        """A list of namedtuples representing metrics in Mentions category:
+        metrics that measure engagement with research.
+        Note: Can be empty. Specific metrics can be absent depending on
+        existence of data and applicability of metrics to document type.
+        For details on Mention metrics see
+        https://plumanalytics.com/learn/about-metrics/mention-metrics/
+        """
+        categories = self._json.get('count_categories', [])
+        mention_metrics = _category_metrics('mention', categories)
+        return _list_metrics_totals(mention_metrics) or None   
+    
+    @property
+    def social_media(self):
+        """A list of namedtuples representing social media metrics:
+        metrics on promotion of research.
+        Note: Can be empty. Specific metrics can be absent depending on
+        existence of data and applicability of metrics to document type.
+        For details on social media metrics see
+        https://plumanalytics.com/learn/about-metrics/social-media-metrics/
+        """
+        categories = self._json.get('count_categories', [])
+        social_metrics = _category_metrics('socialMedia', categories)
+        return _list_metrics_totals(social_metrics) or None   
+    
+    @property
+    def usage(self):
+        """A list of namedtuples representing Usage category metrics:
+        metrics that capture interaction with and usage of research.
+        Note: Can be empty. Specific metrics can be absent depending on
+        existence of data and applicability of metrics to document type.
+        For details on Usage metrics see
+        https://plumanalytics.com/learn/about-metrics/usage-metrics/
+        """
+        categories = self._json.get('count_categories', [])
+        usage_metrics = _category_metrics('usage', categories)
+        return _list_metrics_totals(usage_metrics) or None     
+    
+    def __init__(self, identifier, refresh=False):
+        """Class to represent the results from retrieval request from the
+        Scopus PlumX Metrics API.
+
+        Parameters
+        ----------
+        identifier : str
+            The identifier of a document. Must be Scopus EID.
+
+        refresh : bool or int (optional, default=False)
+            Whether to refresh the cached file if it exists or not.  If int
+            is passed, cached file will be refreshed if the number of days
+            since last modification exceeds that value.
+
+        Raises
+        ------
+        Scopus
+            If the id_type parameter or the view parameter contains
+            invalid entries.
+
+        Notes
+        -----
+        The directory for cached results is `{path}/ENHANCED/{identifier}`,
+        where `path` is specified in `~/.scopus/config.ini`.
+        """
+        Retrieval.__init__(self,
+                           identifier=identifier,
+                           id_type='elsevierId',
+                           api='PlumXMetrics',
+                           refresh=refresh,
+                           view='ENHANCED')
+
+
+def _category_metrics(category_name, categories_list):
+    """Auxiliary function returning all available metrics in a single
+    category as a list of dicts
+    """
+    cat_counts = []
+    for item in categories_list:
+        if item.get('name') == category_name:
+            cat_counts += item.get('count_types', [])
+    return cat_counts
+
+
+def _list_metrics_totals(metric_counts):
+    """Formats list of dicts of metrics into list of namedtuples in form
+    (name, total)
+    """
+    out = []
+    values = [[m.get('name'), m.get('total')] for m in metric_counts
+              if m.get('name') and m.get('total')]
+    fields = 'name total'
+    capture = namedtuple('Metric', fields)
+    for v in values:
+        new = capture(name=v[0], total=v[1])
+        out.append(new)
+    return out

--- a/pybliometrics/scopus/tests/test_PlumXMetrics.py
+++ b/pybliometrics/scopus/tests/test_PlumXMetrics.py
@@ -102,3 +102,4 @@ def test_usage():
     assert_equal(m2_fields, expected)
     assert_equal([i.total for i in m1.usage if i.total <= 0], [])
     assert_equal([i.total for i in m2.usage if i.total <= 0], [])
+

--- a/pybliometrics/scopus/tests/test_PlumXMetrics.py
+++ b/pybliometrics/scopus/tests/test_PlumXMetrics.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Tests for `scopus.PlumXMetrics` module."""
+
+from nose.tools import assert_equal, assert_true
+
+from pybliometrics.scopus import PlumXMetrics
+
+# All PlumX Metrics categories are present
+m1 = PlumXMetrics('2-s2.0-34249753618', refresh=30)
+# No Social Media metrics
+m2 = PlumXMetrics('2-s2.0-84925623234', refresh=30)
+# No PlumX Metrics
+m3 = PlumXMetrics('2-s2.0-84950369844', refresh=30)
+
+
+def test_category_totals():
+    assert_true(isinstance(m1.category_totals, list))
+    assert_true(isinstance(m2.category_totals, list))
+    assert_equal(m3.category_totals, None)
+    cats1 = [i.name for i in m1.category_totals]
+    cats2 = [i.name for i in m2.category_totals]
+    assert_true('socialMedia' in cats1)
+    assert_true('socialMedia' not in cats2)
+    assert_true(len(m1.category_totals) >= 5)
+    assert_true(len(m2.category_totals) >= 4)
+    expected = set(['name', 'total'])
+    m1_fields = set(field for ntup in m1.category_totals for field in ntup._fields)
+    m2_fields = set(field for ntup in m2.category_totals for field in ntup._fields)
+    assert_equal(m1_fields, expected)
+    assert_equal(m2_fields, expected)
+    assert_equal([i.total for i in m1.category_totals if i.total <= 0], [])
+    assert_equal([i.total for i in m2.category_totals if i.total <= 0], [])
+
+
+def test_capture():
+    assert_true(isinstance(m1.capture, list))
+    assert_true(isinstance(m2.capture, list))
+    assert_equal(m3.capture, None)
+    assert_true(len(m1.capture) > 0)
+    assert_true(len(m2.capture) > 0)
+    expected = set(['name', 'total'])
+    m1_fields = set(field for ntup in m1.capture for field in ntup._fields)
+    m2_fields = set(field for ntup in m2.capture for field in ntup._fields)
+    assert_equal(m1_fields, expected)
+    assert_equal(m2_fields, expected)
+    assert_equal([i.total for i in m1.capture if i.total <= 0], [])
+    assert_equal([i.total for i in m2.capture if i.total <= 0], [])
+
+
+def test_citation():
+    assert_true(isinstance(m1.citation, list))
+    assert_true(isinstance(m2.citation, list))
+    assert_equal(m3.citation, None)
+    assert_true(len(m1.citation) > 0)
+    assert_true(len(m2.citation) > 0)
+    expected = set(['name', 'total'])
+    m1_fields = set(field for ntup in m1.citation for field in ntup._fields)
+    m2_fields = set(field for ntup in m2.citation for field in ntup._fields)
+    assert_equal(m1_fields, expected)
+    assert_equal(m2_fields, expected)
+    assert_equal([i.total for i in m1.citation if i.total <= 0], [])
+    assert_equal([i.total for i in m2.citation if i.total <= 0], [])
+
+
+def test_mention():
+    assert_true(isinstance(m1.mention, list))
+    assert_true(isinstance(m2.mention, list))
+    assert_equal(m3.mention, None)
+    assert_true(len(m1.mention) > 0)
+    assert_true(len(m2.mention) > 0)
+    expected = set(['name', 'total'])
+    m1_fields = set(field for ntup in m1.mention for field in ntup._fields)
+    m2_fields = set(field for ntup in m2.mention for field in ntup._fields)
+    assert_equal(m1_fields, expected)
+    assert_equal(m2_fields, expected)
+    assert_equal([i.total for i in m1.mention if i.total <= 0], [])
+    assert_equal([i.total for i in m2.mention if i.total <= 0], [])
+
+
+def test_social_media():
+    assert_true(isinstance(m1.social_media, list))
+    assert_equal(m2.social_media, None)
+    assert_equal(m3.social_media, None)
+    assert_true(len(m1.social_media) > 0)
+    expected = set(['name', 'total'])
+    m1_fields = set(field for ntup in m1.social_media for field in ntup._fields)
+    assert_equal(m1_fields, expected)
+    assert_equal([i.total for i in m1.social_media if i.total <= 0], [])
+
+
+def test_usage():
+    assert_true(isinstance(m1.usage, list))
+    assert_true(isinstance(m2.usage, list))
+    assert_equal(m3.usage, None)
+    assert_true(len(m1.usage) > 0)
+    assert_true(len(m2.usage) > 0)
+    expected = set(['name', 'total'])
+    m1_fields = set(field for ntup in m1.usage for field in ntup._fields)
+    m2_fields = set(field for ntup in m2.usage for field in ntup._fields)
+    assert_equal(m1_fields, expected)
+    assert_equal(m2_fields, expected)
+    assert_equal([i.total for i in m1.usage if i.total <= 0], [])
+    assert_equal([i.total for i in m2.usage if i.total <= 0], [])

--- a/pybliometrics/scopus/utils/constants.py
+++ b/pybliometrics/scopus/utils/constants.py
@@ -9,7 +9,8 @@ DEFAULT_PATHS = {
     'CitationOverview': expanduser('~/.scopus/citation_overview'),
     'ContentAffiliationRetrieval': expanduser('~/.scopus/affiliation_retrieval'),
     'ScopusSearch': expanduser('~/.scopus/scopus_search'),
-    'SerialTitle': expanduser('~/.scopus/serial_title')
+    'SerialTitle': expanduser('~/.scopus/serial_title'),
+    'PlumXMetrics': expanduser('~/.scopus/plumx')
 }
 
 # URL prefix and suffixes for retrieval classes
@@ -19,7 +20,8 @@ RETRIEVAL_URL = {
     'AuthorRetrieval': RETRIEVAL_BASE + 'author/author_id/',
     'CitationOverview': RETRIEVAL_BASE + 'abstract/citations/',
     'ContentAffiliationRetrieval': RETRIEVAL_BASE + 'affiliation/affiliation_id/',
-    'SerialTitle': RETRIEVAL_BASE + 'serial/title/issn/'
+    'SerialTitle': RETRIEVAL_BASE + 'serial/title/issn/',
+    'PlumXMetrics': 'https://api.elsevier.com/analytics/plumx/'
 }
 
 # URL prefix and suffixes for search classes

--- a/pybliometrics/scopus/utils/get_content.py
+++ b/pybliometrics/scopus/utils/get_content.py
@@ -76,7 +76,7 @@ def get_content(url, params={}, *args, **kwds):
         error_type = errors[resp.status_code]
         try:
             reason = resp.json()['service-error']['status']['statusText']
-        except:
+        except KeyError:
             try:
                 reason = resp.json()['message']
             except:

--- a/pybliometrics/scopus/utils/get_content.py
+++ b/pybliometrics/scopus/utils/get_content.py
@@ -77,7 +77,10 @@ def get_content(url, params={}, *args, **kwds):
         try:
             reason = resp.json()['service-error']['status']['statusText']
         except:
-            reason = ""
+            try:
+                reason = resp.json()['message']
+            except:
+                reason = ""
         raise errors[resp.status_code](reason)
     except KeyError:
         resp.raise_for_status()


### PR DESCRIPTION
## Summary
This PR adds `PlumXMetrics` class, which is an implementation of [PlumX Metrics API of Scopus](https://dev.elsevier.com/documentation/PlumXMetricsAPI.wadl). The class allows users to retrieve PlumX metrics for Scopus documents via elsevier ID. `PlumXMetrics` consists of 6 attributes: 1 for each of 5 [categories of PlumX Metrics](https://plumanalytics.com/learn/about-metrics/) and 1 that outputs overall totals by category (exception: totals of Citation category, which is a max citation count from available sources).

An example:
``` python
>>> m = PlumXMetrics("2-s2.0-84964203940", refresh=True)
>>> m.category_totals
[Category(name='capture', total=2772),
 Category(name='citation', total=3662),
 Category(name='mention', total=3),
 Category(name='socialMedia', total=2),
 Category(name='usage', total=6)]
>>> m.capture
[Metric(name='READER_COUNT', total=2770),
 Metric(name='EXPORTS_SAVES', total=2)]
>>> m.citation # Citations by source, max citation count is in .category_totals
[Metric(name='Scopus', total=3662),
 Metric(name='CrossRef', total=2335),
 Metric(name='Academic Citation Index (ACI) - airiti', total=6)]
>>> m.mention
[Metric(name='ALL_BLOG_COUNT', total=2),
 Metric(name='QA_SITE_MENTIONS', total=1)]
>>> m.social_media
[Metric(name='TWEET_COUNT', total=2)]
>>> m.usage
[Metric(name='ABSTRACT_VIEWS', total=4), Metric(name='LINK_OUTS', total=2)]
```
Note:

- The API method of Scopus accepts various document identifiers (e.g. arXiv ID, GitHub repository ID, Soundcloud track ID etc.). However, for now `PlumXMetrics` class works only with elsevier IDs.
- In case of 404 response (e.g. incorrect input EID), the JSON file of PlumXMetrics API is different from other Retrieval classes. For this reason  `pybliometrics/scopus/utils/get_content.py` was changed accordingly by adding another try-except block.