### PR TITLE
ID Types for PlumXMetrics

### DIFF
--- a/pybliometrics/scopus/plumx_metrics.py
+++ b/pybliometrics/scopus/plumx_metrics.py
@@ -102,11 +102,10 @@ class PlumXMetrics(Retrieval):
         Parameters
         ----------
         identifier : str
-            The identifier of a document. Must be Scopus EID.
+            The identifier of a document.
 
         id_type: str
             The type of used ID. Allowed values are:
-                
                 - 'airitiDocId'
                 - 'arxivId'
                 - 'cabiAbstractId'

--- a/pybliometrics/scopus/plumx_metrics.py
+++ b/pybliometrics/scopus/plumx_metrics.py
@@ -10,7 +10,7 @@ class PlumXMetrics(Retrieval):
         by PlumX Metrics in the form (capture, citation, mention, socialMedia,
         usage).
         Note: Can be empty. Specific categories can be absent depending on
-        existence of data and applicability of metrics to document type. For 
+        existence of data and applicability of metrics to document type. For
         Citation category a maximum citation count across sources is shown.
         For details on PlumX Metrics categories see
         https://plumanalytics.com/learn/about-metrics/
@@ -38,7 +38,7 @@ class PlumXMetrics(Retrieval):
         """
         categories = self._json.get('count_categories', [])
         mention_metrics = _category_metrics('capture', categories)
-        return _list_metrics_totals(mention_metrics) or None   
+        return _list_metrics_totals(mention_metrics) or None
     
     @property
     def citation(self):
@@ -68,7 +68,7 @@ class PlumXMetrics(Retrieval):
         """
         categories = self._json.get('count_categories', [])
         mention_metrics = _category_metrics('mention', categories)
-        return _list_metrics_totals(mention_metrics) or None   
+        return _list_metrics_totals(mention_metrics) or None
     
     @property
     def social_media(self):
@@ -81,7 +81,7 @@ class PlumXMetrics(Retrieval):
         """
         categories = self._json.get('count_categories', [])
         social_metrics = _category_metrics('socialMedia', categories)
-        return _list_metrics_totals(social_metrics) or None   
+        return _list_metrics_totals(social_metrics) or None
     
     @property
     def usage(self):
@@ -94,15 +94,52 @@ class PlumXMetrics(Retrieval):
         """
         categories = self._json.get('count_categories', [])
         usage_metrics = _category_metrics('usage', categories)
-        return _list_metrics_totals(usage_metrics) or None     
+        return _list_metrics_totals(usage_metrics) or None
     
-    def __init__(self, identifier, refresh=False):
+    def __init__(self, identifier, id_type, refresh=False):
         """Interaction with the PlumX Metrics API.
 
         Parameters
         ----------
         identifier : str
             The identifier of a document. Must be Scopus EID.
+
+        id_type: str
+            The type of used ID. Allowed values are:
+                
+                - 'airitiDocId'
+                - 'arxivId'
+                - 'cabiAbstractId'
+                - 'citeulikeId'
+                - 'digitalMeasuresArtifactId'
+                - 'doi'
+                - 'elsevierId'
+                - 'elsevierPii'
+                - 'facebookCountUrlId'
+                - 'figshareArticleId'
+                - 'githubRepoId'
+                - 'isbn'
+                - 'lccn'
+                - 'medwaveId'
+                - 'nctId'
+                - 'oclc'
+                - 'pittEprintDscholarId'
+                - 'pmcid'
+                - 'pmid'
+                - 'redditId'
+                - 'repecHandle'
+                - 'repoUrl'
+                - 'scieloId'
+                - 'sdEid'
+                - 'slideshareUrlId'
+                - 'smithsonianPddrId'
+                - 'soundcloudTrackId'
+                - 'ssrnId'
+                - 'urlId'
+                - 'usPatentApplicationId'
+                - 'usPatentPublicationId'
+                - 'vimeoVideoId'
+                - 'youtubeVideoId'
 
         refresh : bool or int (optional, default=False)
             Whether to refresh the cached file if it exists or not.  If int
@@ -114,9 +151,23 @@ class PlumXMetrics(Retrieval):
         The directory for cached results is `{path}/ENHANCED/{identifier}`,
         where `path` is specified in `~/.scopus/config.ini`.
         """
+        allowed_ids = ('airitiDocId', 'arxivId', 'cabiAbstractId',
+                       'citeulikeId', 'digitalMeasuresArtifactId', 'doi',
+                       'elsevierId', 'elsevierPii', 'facebookCountUrlId',
+                       'figshareArticleId', 'githubRepoId', 'isbn',
+                       'lccn', 'medwaveId', 'nctId',
+                       'oclc', 'pittEprintDscholarId', 'pmcid',
+                       'pmid', 'redditId', 'repecHandle',
+                       'repoUrl', 'scieloId', 'sdEid',
+                       'slideshareUrlId', 'smithsonianPddrId', 'soundcloudTrackId',
+                       'ssrnId', 'urlId', 'usPatentApplicationId',
+                       'usPatentPublicationId', 'vimeoVideoId', 'youtubeVideoId')
+        if id_type not in allowed_ids:
+            raise ValueError('Id type must be one of: ' +
+                             ', '.join(allowed_ids))
         Retrieval.__init__(self,
                            identifier=identifier,
-                           id_type='elsevierId',
+                           id_type=id_type,
                            api='PlumXMetrics',
                            refresh=refresh,
                            view='ENHANCED')

--- a/pybliometrics/scopus/tests/test_PlumXMetrics.py
+++ b/pybliometrics/scopus/tests/test_PlumXMetrics.py
@@ -6,100 +6,118 @@ from nose.tools import assert_equal, assert_true
 
 from pybliometrics.scopus import PlumXMetrics
 
-# All PlumX Metrics categories are present
-m1 = PlumXMetrics('2-s2.0-34249753618', refresh=30)
-# No Social Media metrics
-m2 = PlumXMetrics('2-s2.0-84925623234', refresh=30)
-# No PlumX Metrics
-m3 = PlumXMetrics('2-s2.0-84950369844', refresh=30)
+# A published paper. All PlumX Metrics categories are present.
+m1 = PlumXMetrics('2-s2.0-34249753618', 'elsevierId', refresh=30)
+# A published paper. No Usage and Social Media metrics.
+m2 = PlumXMetrics('10.2307/2281868', 'doi', refresh=30)
+# A published paper. No PlumX Metrics.
+m3 = PlumXMetrics('2-s2.0-84950369844', 'elsevierId', refresh=30)
+# An arXiv paper. No Citation metrics.
+m4 = PlumXMetrics('1507.02672', 'arxivId', refresh=30)
+# A published book. No Social Media metrics.
+m5 = PlumXMetrics('9783540783893', 'isbn', refresh=30)
+# A GitHub repository. No Citation metrics.
+m6 = PlumXMetrics('tensorflow/tensorflow', 'githubRepoId', refresh=30)
+# A YouTube video. No Capture and Citation metrics.
+m7 = PlumXMetrics('dQw4w9WgXcQ', 'youtubeVideoId', refresh=30)
+
 
 
 def test_category_totals():
-    assert_true(isinstance(m1.category_totals, list))
-    assert_true(isinstance(m2.category_totals, list))
-    assert_equal(m3.category_totals, None)
-    cats1 = [i.name for i in m1.category_totals]
-    cats2 = [i.name for i in m2.category_totals]
-    assert_true('socialMedia' in cats1)
-    assert_true('socialMedia' not in cats2)
-    assert_true(len(m1.category_totals) >= 5)
-    assert_true(len(m2.category_totals) >= 4)
     expected = set(['name', 'total'])
-    m1_fields = set(field for ntup in m1.category_totals for field in ntup._fields)
-    m2_fields = set(field for ntup in m2.category_totals for field in ntup._fields)
-    assert_equal(m1_fields, expected)
-    assert_equal(m2_fields, expected)
-    assert_equal([i.total for i in m1.category_totals if i.total <= 0], [])
-    assert_equal([i.total for i in m2.category_totals if i.total <= 0], [])
+    assert_equal(m3.category_totals, None)
+    for plumx in (m1, m2, m4, m5, m6, m7):
+        assert_true(isinstance(plumx.category_totals, list))
+        cats = [i.name for i in plumx.category_totals]
+        if plumx in (m2, m5):
+            assert_true('socialMedia' not in cats)
+        else:
+            assert_true('socialMedia' in cats)
+        if plumx in (m1, m2, m5):
+            assert_true('citation' in cats)
+        else:
+            assert_true('citation' not in cats)
+        if plumx != m2:
+            assert_true('usage' in cats)
+        else:
+            assert_true('usage' not in cats)
+        if plumx != m7:
+            assert_true('capture' in cats)
+        else:
+            assert_true('capture' not in cats)
+        if plumx in (m2, m7):
+            assert_true(len(plumx.category_totals) >= 3)
+        elif plumx in (m4, m5, m6):
+            assert_true(len(plumx.category_totals) >= 4)
+        else:
+            assert_true(len(plumx.category_totals) >= 5)
+        m_fields = set(field for ntup in plumx.category_totals for field in ntup._fields)
+        assert_equal(m_fields, expected)
+        zero_totals = [i.total for i in plumx.category_totals if i.total <= 0]
+        assert_equal(zero_totals, [])
 
 
 def test_capture():
-    assert_true(isinstance(m1.capture, list))
-    assert_true(isinstance(m2.capture, list))
-    assert_equal(m3.capture, None)
-    assert_true(len(m1.capture) > 0)
-    assert_true(len(m2.capture) > 0)
     expected = set(['name', 'total'])
-    m1_fields = set(field for ntup in m1.capture for field in ntup._fields)
-    m2_fields = set(field for ntup in m2.capture for field in ntup._fields)
-    assert_equal(m1_fields, expected)
-    assert_equal(m2_fields, expected)
-    assert_equal([i.total for i in m1.capture if i.total <= 0], [])
-    assert_equal([i.total for i in m2.capture if i.total <= 0], [])
+    for plumx in (m3, m7):
+        assert_equal(plumx.capture, None)
+    for plumx in (m1, m2, m4, m5, m6):
+        assert_true(isinstance(plumx.capture, list))
+        assert_true(len(plumx.capture) > 0)
+        m_fields = set(field for ntup in plumx.capture for field in ntup._fields)
+        assert_equal(m_fields, expected)
+        zero_totals = [i.total for i in plumx.capture if i.total <= 0] 
+        assert_equal(zero_totals, [])
 
 
 def test_citation():
-    assert_true(isinstance(m1.citation, list))
-    assert_true(isinstance(m2.citation, list))
-    assert_equal(m3.citation, None)
-    assert_true(len(m1.citation) > 0)
-    assert_true(len(m2.citation) > 0)
     expected = set(['name', 'total'])
-    m1_fields = set(field for ntup in m1.citation for field in ntup._fields)
-    m2_fields = set(field for ntup in m2.citation for field in ntup._fields)
-    assert_equal(m1_fields, expected)
-    assert_equal(m2_fields, expected)
-    assert_equal([i.total for i in m1.citation if i.total <= 0], [])
-    assert_equal([i.total for i in m2.citation if i.total <= 0], [])
+    for plumx in (m3, m4, m6, m7):
+        assert_equal(plumx.citation, None)
+    for plumx in (m1, m2, m5):
+        assert_true(isinstance(plumx.citation, list))
+        assert_true(len(plumx.citation) > 0)
+        m_fields = set(field for ntup in plumx.citation for field in ntup._fields)
+        assert_equal(m_fields, expected)
+        zero_totals = [i.total for i in plumx.citation if i.total <= 0]
+        assert_equal(zero_totals, [])
 
 
 def test_mention():
-    assert_true(isinstance(m1.mention, list))
-    assert_true(isinstance(m2.mention, list))
-    assert_equal(m3.mention, None)
-    assert_true(len(m1.mention) > 0)
-    assert_true(len(m2.mention) > 0)
     expected = set(['name', 'total'])
-    m1_fields = set(field for ntup in m1.mention for field in ntup._fields)
-    m2_fields = set(field for ntup in m2.mention for field in ntup._fields)
-    assert_equal(m1_fields, expected)
-    assert_equal(m2_fields, expected)
-    assert_equal([i.total for i in m1.mention if i.total <= 0], [])
-    assert_equal([i.total for i in m2.mention if i.total <= 0], [])
+    assert_equal(m3.mention, None)
+    for plumx in (m1, m2, m4, m5, m6, m7):
+        assert_true(isinstance(plumx.mention, list))
+        assert_true(len(plumx.mention) > 0)
+        m_fields = set(field for ntup in plumx.mention for field in ntup._fields)
+        assert_equal(m_fields, expected)
+        zero_totals = [i.total for i in plumx.mention if i.total <= 0]
+        assert_equal(zero_totals, [])
 
 
 def test_social_media():
-    assert_true(isinstance(m1.social_media, list))
-    assert_equal(m2.social_media, None)
-    assert_equal(m3.social_media, None)
-    assert_true(len(m1.social_media) > 0)
     expected = set(['name', 'total'])
-    m1_fields = set(field for ntup in m1.social_media for field in ntup._fields)
-    assert_equal(m1_fields, expected)
-    assert_equal([i.total for i in m1.social_media if i.total <= 0], [])
+    for plumx in (m2, m3, m5):
+        assert_equal(plumx.social_media, None)
+    for plumx in (m1, m4, m6, m7):
+        assert_true(isinstance(plumx.social_media, list))
+        assert_true(len(plumx.social_media) > 0)
+        m_fields = set(field for ntup in plumx.social_media for field in ntup._fields)
+        assert_equal(m_fields, expected)
+        zero_totals = [i.total for i in plumx.social_media if i.total <= 0]
+        assert_equal(zero_totals, [])
 
 
 def test_usage():
-    assert_true(isinstance(m1.usage, list))
-    assert_true(isinstance(m2.usage, list))
-    assert_equal(m3.usage, None)
-    assert_true(len(m1.usage) > 0)
-    assert_true(len(m2.usage) > 0)
     expected = set(['name', 'total'])
-    m1_fields = set(field for ntup in m1.usage for field in ntup._fields)
-    m2_fields = set(field for ntup in m2.usage for field in ntup._fields)
-    assert_equal(m1_fields, expected)
-    assert_equal(m2_fields, expected)
-    assert_equal([i.total for i in m1.usage if i.total <= 0], [])
-    assert_equal([i.total for i in m2.usage if i.total <= 0], [])
+    for plumx in (m2, m3):
+        assert_equal(plumx.usage, None)
+    for plumx in (m1, m4, m5, m6, m7):
+        assert_true(isinstance(plumx.usage, list))
+        assert_true(len(plumx.usage) > 0)
+        m_fields = set(field for ntup in plumx.usage for field in ntup._fields)
+        assert_equal(m_fields, expected)
+        zero_totals = [i.total for i in plumx.usage if i.total <= 0]
+        assert_equal(zero_totals, [])
+
 

--- a/pybliometrics/scopus/tests/test_PlumXMetrics.py
+++ b/pybliometrics/scopus/tests/test_PlumXMetrics.py
@@ -22,7 +22,6 @@ m6 = PlumXMetrics('tensorflow/tensorflow', 'githubRepoId', refresh=30)
 m7 = PlumXMetrics('dQw4w9WgXcQ', 'youtubeVideoId', refresh=30)
 
 
-
 def test_category_totals():
     expected = set(['name', 'total'])
     assert_equal(m3.category_totals, None)


### PR DESCRIPTION
## Summary
A required `id_type` argument is added to the constructor of `PlumXMetrics`. Explicit specification of the ID type allows to use the PlumXMetrics API to its fullest with its support of 33 types of document IDs. The docstring of the class constructor was changed accordingly with addition of description of the new argument. The test suite was also changed to have different types of documents.

Examples with some different ID types:
1. PII
```python
from pybliometrics.scopus import PlumXMetrics
>>> m = PlumXMetrics('S0167715218300737', 'elsevierPii', refresh=True)
>>> m.category_totals
[Category(name='capture', total=158),
 Category(name='citation', total=13),
 Category(name='socialMedia', total=13),
 Category(name='usage', total=33)]
>>> m.capture
[Metric(name='READER_COUNT', total=156), Metric(name='EXPORTS_SAVES', total=2)]
>>> m.citation
[Metric(name='Scopus', total=13), Metric(name='CrossRef', total=5)]
>>> m.social_media
[Metric(name='FACEBOOK_COUNT', total=12), Metric(name='TWEET_COUNT', total=1)]
>>> m.usage
[Metric(name='ABSTRACT_VIEWS', total=26), Metric(name='LINK_OUTS', total=7)]
```
2. DOI
```python
>>> m = PlumXMetrics('10.1017/S0266466603192092', 'doi', refresh=True)
>>> m.category_totals
[Category(name='capture', total=179),
 Category(name='citation', total=405),
 Category(name='usage', total=2)]
>>> m.capture
[Metric(name='READER_COUNT', total=179)]
>>> m.citation
[Metric(name='Scopus', total=405), Metric(name='CrossRef', total=212)]
>>> m.usage
[Metric(name='ABSTRACT_VIEWS', total=2)]
```
3. ISBN
```python
>>> m = PlumXMetrics('9780387985022', 'isbn', refresh=True)
>>> m.category_totals
[Category(name='capture', total=190),
 Category(name='citation', total=9),
 Category(name='mention', total=38),
 Category(name='socialMedia', total=2),
 Category(name='usage', total=4685)]
>>> m.capture
[Metric(name='EXPORTS_SAVES', total=116),
 Metric(name='READER_COUNT', total=74)]
>>> m.citation
[Metric(name='CrossRef', total=9)]
>>> m.mention
[Metric(name='REFERENCE_COUNT', total=25),
 Metric(name='REVIEW_COUNT', total=12),
 Metric(name='QA_SITE_MENTIONS', total=1)]
>>> m.social_media
[Metric(name='TWEET_COUNT', total=2)]
>>> m.usage
[Metric(name='HOLDINGS_COUNT', total=2652),
 Metric(name='ABSTRACT_VIEWS', total=1312),
 Metric(name='FULL_TEXT_VIEWS', total=642),
 Metric(name='DOWNLOAD_COUNT', total=55),
 Metric(name='LINK_OUTS', total=24)]
```
4. GitHub repository
```python
>>> m = PlumXMetrics('microsoft/STL', 'githubRepoId', refresh=True)
>>> m.category_totals
[Category(name='capture', total=5709),
 Category(name='mention', total=6),
 Category(name='socialMedia', total=1322)]
>>> m.capture
[Metric(name='WATCHER_COUNT', total=5131),
 Metric(name='FORK_COUNT', total=578)]
>>> m.mention
[Metric(name='NEWS_COUNT', total=4), Metric(name='REFERENCE_COUNT', total=2)]
>>> m.social_media
[Metric(name='TWEET_COUNT', total=1177),
 Metric(name='FACEBOOK_COUNT', total=145)]
```
5. YouTube video
```python
>>> m = PlumXMetrics('WJBgGUeSHuw', "youtubeVideoId", refresh=True)
>>> m.category_totals
[Category(name='mention', total=1),
 Category(name='socialMedia', total=9),
 Category(name='usage', total=10233)]
>>> m.mention
[Metric(name='COMMENT_COUNT', total=1)]
>>> m.social_media
[Metric(name='LIKE_COUNT', total=7), Metric(name='FACEBOOK_COUNT', total=2)]
>>> m.usage
[Metric(name='PLAY_COUNT', total=10233)]
```