### PR TITLE
adding additionally provided parameters into account for the search paramters

### DIFF
--- a/pybliometrics/scopus/superclasses/search.py
+++ b/pybliometrics/scopus/superclasses/search.py
@@ -60,7 +60,7 @@ class Search(Base):
         ValueError
             If the api parameter is an invalid entry.
         """
-        params = {'count': count, 'view': view}
+        params = {'count': count, 'view': view, **kwds}
         if isinstance(query, dict):
             params.update(query)
             name = "&".join(["=".join(t) for t in zip(query.keys(), query.values())])


### PR DESCRIPTION
For large result sets we would like to restrict the query result to show only the eids. Hence we need to set the field=eid in the url. The documentation says, that this can be achieved, however, the provided parameter was not added to the url paramters.