### PR TITLE
Implement Subject Classifications

### DIFF
--- a/pybliometrics/scopus/__init__.py
+++ b/pybliometrics/scopus/__init__.py
@@ -10,4 +10,5 @@ from pybliometrics.scopus.author_search import *
 from pybliometrics.scopus.scopus_search import *
 from pybliometrics.scopus.serial_search import *
 from pybliometrics.scopus.serial_title import *
+from pybliometrics.scopus.subj_class import *
 

--- a/pybliometrics/scopus/subj_class.py
+++ b/pybliometrics/scopus/subj_class.py
@@ -1,0 +1,88 @@
+from collections import namedtuple
+
+from pybliometrics.scopus.superclasses import Search
+
+
+class SubjectClass(Search):
+    @property
+    def results(self):
+        """A list of namedtuples representing results of subject classifications
+        search. The number of fields of namedtuples are specified during class
+        initialization. Note: can be empty if no results are found.
+        """
+        out = []
+        subj = namedtuple('Subject', self.fields)
+        search_results = self._json['subject-classifications'].get(
+                'subject-classification', []
+                )
+        if isinstance(search_results, dict):
+            for field_name in self.fields:
+                if not field_name in search_results:
+                    search_results[field_name] = None
+            out.append(subj(**search_results))                
+        else:            
+            for result in search_results:
+                missing_fields = set(self.fields).difference(set(result.keys()))
+                if missing_fields:
+                    for field_name in missing_fields:
+                        result[field_name] = None
+                out.append(subj(**result))
+        return out or None
+        
+    def __init__(self, query, fields=None, refresh=False):
+        """Interaction with the Subject Classifications Scopus API.
+
+        Parameters
+        ----------
+        query: dict
+            Query parameters and corresponding fields. Allowed keys 'code',
+            'abbrev', 'description', 'detail'. For more details on search fields
+            please refer to
+            https://dev.elsevier.com/documentation/SubjectClassificationsAPI.wadl#d1e199.
+        
+        fields : iterable (optional, default=None)
+            The fields to return when calling search results. Allowed values:
+            'code', 'abbrev', 'description', 'detail'.  For details see
+            https://dev.elsevier.com/documentation/SubjectClassificationsAPI.wadl#d1e199.
+        
+        refresh : bool or int (optional, default=False)
+            Whether to refresh the cached file if it exists or not.  If int
+            is passed, cached file will be refreshed if the number of days
+            since last modification exceeds that value.
+
+        Raises
+        ------
+        ValueError
+            If query or return fields contain invalid fields.
+        
+        TypeError
+            If returned fields are not passed in an iterable container.     
+
+        Notes
+        -----
+        The directory for cached results is `{path}/STANDARD/{fname}`,
+        where `path` is specified in `~/.scopus/config.ini` and fname is
+        the md5-hashed version of `query` dict turned into string in format
+        of 'key=value' delimited by '&'.
+        """
+        # Checks
+        allowed_query_keys = ('code', 'description', 'detail', 'abbrev')
+        invalid = [k for k in query.keys() if k not in allowed_query_keys]
+        if invalid:
+            raise ValueError(f'Query key(s) "{", ".join(invalid)}" invalid')
+        self.fields = allowed_query_keys
+        if fields:
+            try:
+                return_fields = [i for i in fields]
+            except TypeError:
+                print("Fields must be iterable")
+                raise
+            if not set(return_fields).issubset(set(allowed_query_keys)):
+                raise ValueError('Returned fields can only be '
+                                 + str(allowed_query_keys))
+            self.fields = fields
+        
+        # Query
+        query['field'] = ','.join(self.fields)
+        self.query = str(query)
+        Search.__init__(self, query=query, api='SubjectClass', refresh=refresh)

--- a/pybliometrics/scopus/superclasses/search.py
+++ b/pybliometrics/scopus/superclasses/search.py
@@ -20,7 +20,8 @@ class Search(Base):
 
         api : str
             The name of the Scopus API to be accessed.  Allowed values:
-            AffiliationSearch, AuthorSearch, ScopusSearch.
+            AffiliationSearch, AuthorSearch, ScopusSearch, SerialSearch,
+            SubjectClass
 
         refresh : bool or int
             Whether to refresh the cached file if it exists or not.  If int

--- a/pybliometrics/scopus/tests/test_SubjectClass.py
+++ b/pybliometrics/scopus/tests/test_SubjectClass.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for `scopus.SubjectClass` module."""
+
+from nose.tools import assert_equal, assert_true
+
+from pybliometrics.scopus import SubjectClass
+
+
+# Search by words in subject description
+sub1 = SubjectClass({'description': 'Physics'}, refresh=30)
+# Search by subject code
+sub2 = SubjectClass({'code': '2613'}, refresh=30)
+# Search by words in subject detail
+sub3 = SubjectClass({'detail': 'Processes'}, refresh=30)
+# Search by subject abbreviation
+sub4 = SubjectClass({'abbrev': 'MATH'}, refresh=30)
+# Search by multiple criteria
+sub5 = SubjectClass({'description': 'Engineering', 'detail':'Fluid'}, refresh=30)
+# Search by multiple criteria, subset returned fields
+sub6 = SubjectClass({'detail': 'Analysis', 'description':'Mathematics'},
+                    fields=['description', 'detail'],
+                    refresh=30)
+
+
+def test_results_desc():
+    assert_true(len(sub1.results) > 0)
+    assert_true(False not in ['Physics' in res.description for res in sub1.results])
+
+
+def test_results_code():
+    assert_equal(len(sub2.results), 1)
+    assert_equal(sub2.results[0].code, '2613')
+    
+
+def test_results_detail():
+    assert_true(len(sub3.results) > 0)
+    assert_true(False not in ['Processes' in res.detail for res in sub3.results])
+
+
+def test_results_abbrev():
+    assert_true(len(sub4.results) > 0)
+    assert_true(False not in ['MATH' in res.abbrev for res in sub4.results])
+
+
+def test_results_multi():
+    assert_true(len(sub5.results) > 0)
+    assert_true(False not in ['Engineering' in res.description for res in sub5.results])
+    assert_true(False not in ['Fluid' in res.detail for res in sub5.results])
+    
+
+def test_results_fields():
+    assert_true(len(sub6.results) > 0)
+    assert_true(False not in ['Mathematics' in res.description for res in sub6.results])
+    assert_true(False not in ['Analysis' in res.detail for res in sub6.results])
+    assert_true(False not in [set(res._fields) == set(['description', 'detail']) for res in sub6.results])

--- a/pybliometrics/scopus/utils/constants.py
+++ b/pybliometrics/scopus/utils/constants.py
@@ -11,7 +11,8 @@ DEFAULT_PATHS = {
     'ScopusSearch': expanduser('~/.scopus/scopus_search'),
     'SerialSearch': expanduser('~/.scopus/serial_search'),
     'SerialTitle': expanduser('~/.scopus/serial_title'),
-    'PlumXMetrics': expanduser('~/.scopus/plumx')
+    'PlumXMetrics': expanduser('~/.scopus/plumx'),
+    'SubjectClass': expanduser('~/.scopus/subject_class')
 }
 
 # URL prefix and suffixes for retrieval classes
@@ -22,7 +23,7 @@ RETRIEVAL_URL = {
     'AuthorRetrieval': RETRIEVAL_BASE + 'author/author_id/',
     'CitationOverview': RETRIEVAL_BASE + 'abstract/citations/',
     'SerialTitle': RETRIEVAL_BASE + 'serial/title/issn/',
-    'PlumXMetrics': 'https://api.elsevier.com/analytics/plumx/'
+    'PlumXMetrics': 'https://api.elsevier.com/analytics/plumx/',
 }
 
 # URL prefix and suffixes for search classes
@@ -31,5 +32,6 @@ SEARCH_URL = {
     'AffiliationSearch': SEARCH_BASE + 'affiliation',
     'AuthorSearch': SEARCH_BASE + 'author',
     'ScopusSearch': SEARCH_BASE + 'scopus',
-    'SerialSearch': RETRIEVAL_BASE + 'serial/title'
+    'SerialSearch': RETRIEVAL_BASE + 'serial/title',
+    'SubjectClass': RETRIEVAL_BASE + 'subject/scopus'
 }


### PR DESCRIPTION
`SubjectClass` class implements ![Subject Classifications API of Scopus](https://dev.elsevier.com/documentation/SubjectClassificationsAPI.wadl#d1e199). It can be used to search for subjects as classified by Scopus. Subjects can be queried by their "description" (general classification of the subject), "code" (unique number assigned by Scopus), "detail" (detailed name of the subject), "abbrev" (abbreviation of general classification of subject) or a combination of those. Like in `SerialSearch`, the query is passed as a Python `dict`. The class has only one method - `SubjectClass.results` - which returns a list of `namedtuples`. By default, the API returns description, code, detail and abbreviation of each found subject, which is also reflected in the fields of `namedtuples` of `SubjectClass.results`. A user can specify the fields to be returned in the search results (e.g. only codes of subjects).  This was accounted for in the class definition via `fields` keyword argument, which checks whether the iterable of passed fields is correct and specifies the fields to be returned in `namedtuples` accordingly.

Some examples:
```python
>>> from pybliometrics.scopus import SubjectClass
# Retrieve all subjects in a broader 'Mathematics' category 
>>> sub1 = SubjectClass({'description': 'Mathematics'}, refresh=30)
>>> sub1.results
[Subject(code='2600', description='Mathematics', detail='Mathematics (all)', abbrev='MATH'),
 Subject(code='2601', description='Mathematics', detail='Mathematics (miscellaneous)', abbrev='MATH'),
 Subject(code='2602', description='Mathematics', detail='Algebra and Number Theory', abbrev='MATH'),
 Subject(code='2603', description='Mathematics', detail='Analysis', abbrev='MATH'),
 Subject(code='2604', description='Mathematics', detail='Applied Mathematics', abbrev='MATH'),
 Subject(code='2605', description='Mathematics', detail='Computational Mathematics', abbrev='MATH'),
 Subject(code='2606', description='Mathematics', detail='Control and Optimization', abbrev='MATH'),
 Subject(code='2607', description='Mathematics', detail='Discrete Mathematics and Combinatorics', abbrev='MATH'),
 Subject(code='2608', description='Mathematics', detail='Geometry and Topology', abbrev='MATH'),
 Subject(code='2609', description='Mathematics', detail='Logic', abbrev='MATH'),
 Subject(code='2610', description='Mathematics', detail='Mathematical Physics', abbrev='MATH'),
 Subject(code='2611', description='Mathematics', detail='Modeling and Simulation', abbrev='MATH'),
 Subject(code='2612', description='Mathematics', detail='Numerical Analysis', abbrev='MATH'),
 Subject(code='2613', description='Mathematics', detail='Statistics and Probability', abbrev='MATH'),
 Subject(code='2614', description='Mathematics', detail='Theoretical Computer Science', abbrev='MATH')]

# Same query but only subjects with 'Mathematics' in their detail
>>> sub2 = SubjectClass({'description': 'Mathematics', 'detail': 'Mathematics'}, refresh=30)
>>> sub2.results
[Subject(code='2600', description='Mathematics', detail='Mathematics (all)', abbrev='MATH'),
 Subject(code='2601', description='Mathematics', detail='Mathematics (miscellaneous)', abbrev='MATH'),
 Subject(code='2604', description='Mathematics', detail='Applied Mathematics', abbrev='MATH'),
 Subject(code='2605', description='Mathematics', detail='Computational Mathematics', abbrev='MATH'),
 Subject(code='2607', description='Mathematics', detail='Discrete Mathematics and Combinatorics', abbrev='MATH')]

# Same query but with restricted fields in specified order
>>> sub3 = SubjectClass({'description': 'Mathematics', 'detail': 'Mathematics'},
                        fields=['detail', 'code'],
                        refresh=30)
>>> sub3.results
[Subject(detail='Mathematics (all)', code='2600'),
 Subject(detail='Mathematics (miscellaneous)', code='2601'),
 Subject(detail='Applied Mathematics', code='2604'),
 Subject(detail='Computational Mathematics', code='2605'),
 Subject(detail='Discrete Mathematics and Combinatorics', code='2607')]
```

`SubjectClass` can be combined with the existing classes of pybliometrics
```python
>>> from pybliometrics.scopus import SerialSearch
>>> import pandas as pd
>>> sub4 = SubjectClass({'detail':'Mechanics'}, fields=['code'])
>>> codes = ','.join([s.code for s in sub4.results])
>>> ser = SerialSearch({'subjCode':codes}, view='STANDARD')
>>> df = pd.DataFrame(ser.results)
>>> df[['title','subject_area_names']].tail()
                                                 title  \
195  Journal of Achievements in Materials and Manuf...   
196                                Journal of Adhesion   
197         Journal of Adhesion Science and Technology   
198                      Journal of Advanced Materials   
199                    Journal of Alloys and Compounds   

                                    subject_area_names  
195  Materials Science (all);Mechanics of Materials...  
196  Surfaces and Interfaces;Mechanics of Materials...  
197  Surfaces and Interfaces;Mechanics of Materials...  
198  Materials Science (all);Mechanics of Materials...  
199  Mechanics of Materials;Mechanical Engineering;...  