### PR TITLE
Handle multiple corresponding authors in AbstractRetrieval

### DIFF
--- a/pybliometrics/scopus/abstract_retrieval.py
+++ b/pybliometrics/scopus/abstract_retrieval.py
@@ -212,7 +212,7 @@ class AbstractRetrieval(Retrieval):
 
     @property
     def correspondence(self):
-        """List of namedtuple representing the authors to whom correspondence
+        """List of namedtuples representing the authors to whom correspondence
         should be addressed, in the form (surname, initials, organization,
         country, city_group). Multiple organziations are joined on semicolon.
         """


### PR DESCRIPTION
This is a suggestion for fixing #185. To handle both possible data types of the `correspondence` field, I listified the value and switched to iterating and returning a list.