### PR TITLE
Add funding id to Funding class

### DIFF
--- a/pybliometrics/scopus/abstract_retrieval.py
+++ b/pybliometrics/scopus/abstract_retrieval.py
@@ -269,14 +269,24 @@ class AbstractRetrieval(Retrieval):
         """List of namedtuples parsed funding information in the form
         (agency string id acronym country).
         """
+
+        def _funding_id(f_dict: dict) -> list:
+            funding_id = []
+            if isinstance(f_dict.get('xocs:funding-id'), str):  # single
+                funding_id = [f_dict.get('xocs:funding-id')]
+            elif isinstance(f_dict.get('xocs:funding-id'), list):  # multiple
+                funding_id = [v['$'] for v in f_dict.get('xocs:funding-id')]
+            return funding_id
+
         path = ['item', 'xocs:meta', 'xocs:funding-list', 'xocs:funding']
         funds = listify(chained_get(self._json, path, []))
         out = []
-        fund = namedtuple('Funding', 'agency string id acronym country')
+        fund = namedtuple('Funding', 'agency string id funding_id acronym country')
         for item in funds:
             new = fund(agency=item.get('xocs:funding-agency'),
                 string=item.get('xocs:funding-agency-matched-string'),
                 id=item.get('xocs:funding-agency-id'),
+                funding_id=_funding_id(item),
                 acronym=item.get('xocs:funding-agency-acronym'),
                 country=item.get('xocs:funding-agency-country'))
             out.append(new)

--- a/pybliometrics/scopus/abstract_retrieval.py
+++ b/pybliometrics/scopus/abstract_retrieval.py
@@ -284,11 +284,11 @@ class AbstractRetrieval(Retrieval):
         fund = namedtuple('Funding', 'agency string id funding_id acronym country')
         for item in funds:
             new = fund(agency=item.get('xocs:funding-agency'),
-                string=item.get('xocs:funding-agency-matched-string'),
-                id=item.get('xocs:funding-agency-id'),
-                funding_id=_funding_id(item),
-                acronym=item.get('xocs:funding-agency-acronym'),
-                country=item.get('xocs:funding-agency-country'))
+                       string=item.get('xocs:funding-agency-matched-string'),
+                       id=item.get('xocs:funding-agency-id'),
+                       funding_id=_funding_id(item),
+                       acronym=item.get('xocs:funding-agency-acronym'),
+                       country=item.get('xocs:funding-agency-country'))
             out.append(new)
         return out or None
 


### PR DESCRIPTION
Closes #210 

This feature includes a `funding_id` (a.k.a. and award/grant number) to the Funding `nametuple` from Scopus `xcors:funding-id` data.

Note that more than one record is available - PR handles a single award (`str`) and multiples (`list` of `dict`).
To ensure a consistent object type, I adopted the Funding `funding_id` field as a `list` of `strings`.

The example in the docs is of a record that does not have a funding-id data. Should we use another example then to reveal the full `Funding` data, @Michael-E-Rose?