### PR TITLE
Add ORCiD in AuthorSearch

### DIFF
--- a/docs/classes/AuthorSearch.rst
+++ b/docs/classes/AuthorSearch.rst
@@ -30,7 +30,7 @@ You can obtain a search summary just by printing the object:
 .. code-block:: python
 
     >>> print(s)
-    Search 'AUTHLAST(Selten) and AUTHFIRST(Reinhard)' yielded 2 authors as of 2020-07-13:
+    Search 'AUTHLAST(Selten) and AUTHFIRST(Reinhard)' yielded 2 authors as of 2021-11-12:
         Selten, Reinhard; AUTHOR_ID:6602907525 (74 document(s))
         Selten, Reinhard; AUTHOR_ID:57213632570 (1 document(s))
 
@@ -41,7 +41,7 @@ To know the the number of results use the `.get_results_size()` method, even bef
 
     >>> other = AuthorSearch("AUTHLAST(Selten)", download=False)
     >>> other.get_results_size()
-    27
+    29
 
 
 The class mostly provides a list of `namedtuples <https://docs.python.org/3/library/collections.html#collections.namedtuple>`_ storing author EIDs, which you can use for the :doc:`AuthorRetrieval <../classes/AuthorRetrieval>` class, and corresponding information:
@@ -49,7 +49,7 @@ The class mostly provides a list of `namedtuples <https://docs.python.org/3/libr
 .. code-block:: python
 
     >>> s.authors[0]
-    [Author(eid='9-s2.0-6602907525', surname='Selten', initials='R.',
+    [Author(eid='9-s2.0-6602907525', orcid=None, surname='Selten', initials='R.',
      givenname='Reinhard', affiliation='Universitat Bonn', documents=74,
      affiliation_id='60007493', city='Bonn', country='Germany',
      areas='ECON (73); MATH (19); BUSI (16)')]
@@ -62,9 +62,9 @@ It's easy to work with namedtuples: Using `pandas <https://pandas.pydata.org/>`_
     >>> import pandas as pd
     >>> pd.set_option('display.max_columns', None)
     >>> print(pd.DataFrame(s.authors))
-                      eid surname initials givenname  \
-    0   9-s2.0-6602907525  Selten       R.  Reinhard   
-    1  9-s2.0-57213632570  Selten       R.  Reinhard   
+                      eid orcid surname initials givenname  \
+    0   9-s2.0-6602907525  None Selten       R.  Reinhard
+    1  9-s2.0-57213632570  None Selten       R.  Reinhard
 
                          affiliation  documents affiliation_id     city  country  \
     0               Universität Bonn         74       60007493     Bonn  Germany   

--- a/pybliometrics/scopus/author_search.py
+++ b/pybliometrics/scopus/author_search.py
@@ -11,7 +11,7 @@ class AuthorSearch(Search):
     def authors(self) -> Optional[List[NamedTuple]]:
         """A list of namedtuples storing author information,
         where each namedtuple corresponds to one author.
-        The information in each namedtuple is (eid surname initials givenname
+        The information in each namedtuple is (eid orcid surname initials givenname
         documents affiliation affiliation_id city country areas).
 
         All entries are strings or None.  Areas combines abbreviated subject
@@ -24,7 +24,7 @@ class AuthorSearch(Search):
             actual field names (listed above).
         """
         # Initiate namedtuple with ordered list of fields
-        fields = 'eid surname initials givenname affiliation documents '\
+        fields = 'eid orcid surname initials givenname affiliation documents '\
                  'affiliation_id city country areas'
         auth = namedtuple('Author', fields)
         check_field_consistency(self._integrity, fields)
@@ -37,8 +37,11 @@ class AuthorSearch(Search):
                               [{'@abbrev': '', '@frequency': ''}])
             areas = [f"{d.get('@abbrev', '')} ({d.get('@frequency', '')})"
                      for d in listify(fields)]
-            new = auth(eid=item.get('eid'), initials=name.get('initials'),
-                       surname=name.get('surname'), areas="; ".join(areas),
+            new = auth(eid=item.get('eid'),
+                       orcid=item.get('orcid'),
+                       initials=name.get('initials'),
+                       surname=name.get('surname'),
+                       areas="; ".join(areas),
                        givenname=name.get('given-name'),
                        documents=int(item['document-count']),
                        affiliation=aff.get('affiliation-name'),

--- a/pybliometrics/scopus/tests/test_AuthorSearch.py
+++ b/pybliometrics/scopus/tests/test_AuthorSearch.py
@@ -14,10 +14,10 @@ s2 = AuthorSearch('authlast(selten)', download=False, refresh=True)
 def test_authors():
     assert_true(isinstance(s1.authors, list))
     assert_true(len(s1.authors) >= 2)
-    order = 'eid surname initials givenname affiliation documents '\
+    order = 'eid orcid surname initials givenname affiliation documents '\
             'affiliation_id city country areas'
     Author = namedtuple('Author', order)
-    expected = Author(eid='9-s2.0-6602907525', surname='Selten',
+    expected = Author(eid='9-s2.0-6602907525', orcid=None, surname='Selten',
         initials='R.', givenname='Reinhard', affiliation='Universität Bonn',
         documents=74, affiliation_id='60007493', city='Bonn',
         country='Germany', areas='ECON (73); MATH (19); BUSI (16)')


### PR DESCRIPTION
Related to #214 
 
This should be sufficient.

Tested against myself (see below) as well as unit test cases where ORCiD was not available:
``` python
from pybliometrics.scopus import AuthorSearch
test = AuthorSearch('ORCID(0000-0002-4245-2318)')
test.authors
[Author(eid='9-s2.0-13608366900',
        orcid='0000-0002-4245-2318',
        surname='Ly', initials='C.', givenname='Chun',
        affiliation='The University of Arizona', documents=41,
        affiliation_id='60010065', city='Tucson', country='United States',
        areas='PHYS (49); EART (37); MULT (1)')]
```