### PR TITLE
Add ORCiD ID in AbstractRetrieval

### DIFF
--- a/docs/classes/AbstractRetrieval.rst
+++ b/docs/classes/AbstractRetrieval.rst
@@ -116,11 +116,11 @@ The same structure applies for the attributes `affiliation` and `authorgroup`:
     [Author(affiliation_id=60105007, dptid=None,
      organization='Max Planck Institute for Innovation and Competition',
      city=None, postalcode=None, addresspart=None, country='Germany',
-     auid=57209617104, indexed_name='Rose M.E.', surname='Rose', given_name='Michael E.'),
+     auid=57209617104, orcid=None, indexed_name='Rose M.E.', surname='Rose', given_name='Michael E.'),
      Author(affiliation_id=60027950, dptid=110785688,
      organization='Carnegie Mellon University, Department of Chemical Engineering',
      city=None, postalcode=None, addresspart=None, country='United States',
-     auid=7004212771, indexed_name='Kitchin J.R.', surname='Kitchin', given_name='John R.')]
+     auid=7004212771, orcid=None, indexed_name='Kitchin J.R.', surname='Kitchin', given_name='John R.')]
 
 
 Keep in mind that Scopus might not perfectly/correctly pair authors and affiliations as per the original document, even if it looks so on the web view.  In this case please request corrections to be made in Scopus' API here `here <https://service.elsevier.com/app/contact/supporthub/scopuscontent/>`_.

--- a/pybliometrics/scopus/abstract_retrieval.py
+++ b/pybliometrics/scopus/abstract_retrieval.py
@@ -59,7 +59,7 @@ class AbstractRetrieval(Retrieval):
         """
         out = []
         fields = 'affiliation_id dptid organization city postalcode '\
-                 'addresspart country auid indexed_name surname given_name'
+                 'addresspart country auid orcid indexed_name surname given_name'
         auth = namedtuple('Author', fields)
         items = listify(self._head.get('author-group', []))
         index_path = ['preferred-name', 'ce:indexed-name']
@@ -83,6 +83,7 @@ class AbstractRetrieval(Retrieval):
                            postalcode=aff.get('postal-code'),
                            addresspart=aff.get('address-part'),
                            country=aff.get('country'), auid=int(au['@auid']),
+                           orcid=au.get('@orcid'),
                            surname=au.get('ce:surname'), given_name=given,
                            indexed_name=chained_get(au, index_path))
                 out.append(new)

--- a/pybliometrics/scopus/abstract_retrieval.py
+++ b/pybliometrics/scopus/abstract_retrieval.py
@@ -50,11 +50,11 @@ class AbstractRetrieval(Retrieval):
     def authorgroup(self) -> Optional[List[NamedTuple]]:
         """A list of namedtuples representing the article's authors organized
         by affiliation, in the form (affiliation_id, dptid, organization,
-        city, postalcode, addresspart, country, auid, indexed_name,
+        city, postalcode, addresspart, country, auid, orcid, indexed_name,
         surname, given_name).
         If "given_name" is not present, fall back to initials.
         Note: Affiliation information might be missing or mal-assigned even
-        when it lookes correct in the web view.  In this case please request
+        when it looks correct in the web view.  In this case please request
         a correction.
         """
         out = []

--- a/pybliometrics/scopus/tests/test_AbstractRetrieval.py
+++ b/pybliometrics/scopus/tests/test_AbstractRetrieval.py
@@ -63,12 +63,12 @@ def test_authkeywords():
 
 def test_authorgroup():
     fields = 'affiliation_id dptid organization city postalcode '\
-             'addresspart country auid indexed_name surname given_name'
+             'addresspart country auid orcid indexed_name surname given_name'
     auth = namedtuple('Author', fields)
     expected = [auth(affiliation_id=60027950, dptid=110785688,
         organization='Department of Chemical Engineering, Carnegie Mellon University',
         city='Pittsburgh', postalcode='15213', addresspart='5000 Forbes Avenue',
-        country='United States', auid=7004212771,
+        country='United States', auid=7004212771, orcid=None,
         indexed_name='Kitchin J.', surname='Kitchin', given_name='John R.')]
     assert_equal(ab1.authorgroup, expected)
     assert_equal(ab8.authorgroup, None)


### PR DESCRIPTION
Closes #217

- [x] Updated `AbstractRetrieval.authorgroup` property
- [x] Updated unit test, docs
