### PR TITLE
Fix #241

### DIFF
--- a/pybliometrics/scopus/utils/get_content.py
+++ b/pybliometrics/scopus/utils/get_content.py
@@ -55,6 +55,8 @@ def get_content(url, api, params={}, **kwds):
     from pybliometrics.scopus.utils.startup import _throttling_params, KEYS
 
     # Set header, params and proxy
+    if len(KEYS) == 0:
+        raise errors[429]
     header = {'X-ELS-APIKey': KEYS[0],
               'Accept': 'application/json',
               'User-Agent': user_agent}


### PR DESCRIPTION
If Scopus continues to answer with 429, pybliometrics will deleted all the keys until it is left with none. At the next call (after the first exception, which is correctly thrown), it will throw an IndexError. This will raise the same exception thrown the first time (Scopus429Error). This fixes #241 