### PR TITLE
Implements returning identified ISSNs on full view

### DIFF
--- a/pybliometrics/scopus/tests/test_AbstractRetrieval.py
+++ b/pybliometrics/scopus/tests/test_AbstractRetrieval.py
@@ -25,6 +25,8 @@ ab7 = AbstractRetrieval("2-s2.0-85050253030", view="FULL", refresh=30)
 ab8 = AbstractRetrieval("2-s2.0-84951753303", view="REF", refresh=30)
 # Collaboration
 ab9 = AbstractRetrieval("2-s2.0-85097473741", view="FULL", refresh=30)
+# ISSN Fallback
+ab10 = AbstractRetrieval("2-s2.0-85144468231", view="META", refresh=30)
 
 
 def test_abstract():
@@ -306,9 +308,21 @@ def test_isbn():
 
 
 def test_issn():
-    assert_equal(ab1.issn, '21555435')
+    issn = namedtuple('ISSN', 'issn type')
+    assert_equal(ab1.issn, issn('21555435', 'print'))
+    received1 = ab3.issn
+    assert_true(isinstance(received1, list))
+    expected1 = issn('03425843', 'print')
+    expected2 = issn('15730700', 'electronic')
+    assert_true(expected1 in received1)
+    assert_true(expected2 in received1)
     assert_equal(ab5.issn, None)
     assert_equal(ab8.issn, None)
+    received2 = ab10.issn
+    expected3 = issn('24739537', None)
+    expected4 = issn('24739529', None)
+    assert_true(expected3 in received2)
+    assert_true(expected4 in received2)
 
 
 def test_identifier():


### PR DESCRIPTION
This PR addresses conversation in #52 

1. Added ISSN named tuple in the form of (issn, type) for values returned on the AbstractRetrieval class.
2. Type returns None if the view is not 'FULL'
3. Returns a list whether one or more