### PR TITLE
#293 AbstractRetrieval queries and downloads all references found

### DIFF
--- a/pybliometrics/scopus/serial_title.py
+++ b/pybliometrics/scopus/serial_title.py
@@ -28,7 +28,7 @@ class SerialTitle(Retrieval):
 
         For more information check the [CiteScore documentation](https://service.elsevier.com/app/answers/detail/a_id/14880/supporthub/scopus/)
         """
-
+        
         try:
             data = self._entry.get('citeScoreYearInfoList', {})
         except KeyError:
@@ -46,9 +46,9 @@ class SerialTitle(Retrieval):
 
         # Extract depending on view
         if self._view in ('STANDARD', 'ENHANCED'):
-            new_data = _getTwoCiteScoreYears(self, named_info_list, data)
+            new_data = _get_two_cite_score_years(self, named_info_list, data)
         elif self._view == 'CITESCORE':
-            new_data = _getAllCiteScoreYears(
+            new_data = _get_all_cite_score_years(
                 self, named_info_list, named_rank_list, data)
 
         return new_data or None
@@ -276,7 +276,8 @@ def _parse_list(d, metric):
         return None
 
 
-def _getAllCiteScoreYears(self, named_info_list, named_rank_list, data) -> Optional[List[NamedTuple]]:
+def _get_all_cite_score_years(self, named_info_list, named_rank_list, data) -> Optional[List[NamedTuple]]:
+    """Auxiliary function to get all information contained in cite score information list for the `CITESCORE` view"""
     data = data.get('citeScoreYearInfo', [])
 
     new_data = []
@@ -307,7 +308,8 @@ def _getAllCiteScoreYears(self, named_info_list, named_rank_list, data) -> Optio
     return new_data or None
 
 
-def _getTwoCiteScoreYears(self, named_info_list, data) -> Optional[List[NamedTuple]]:
+def _get_two_cite_score_years(self, named_info_list, data) -> Optional[List[NamedTuple]]:
+    """Auxiliary function to get information contained in cite score information list for the `STANDARD` and `ENHANCED` view"""
 
     def create_namedtuple(data, mode, named_info_list):
         year = data.get(f'citeScore{mode}Year')

--- a/pybliometrics/scopus/serial_title.py
+++ b/pybliometrics/scopus/serial_title.py
@@ -282,9 +282,9 @@ def _getAllCiteScoreYears(self, named_info_list, named_rank_list, data) -> Optio
     for d in data:
         citeScoreInfo = d.get('citeScoreInformationList', [])[0].get('citeScoreInfo', [])[0]
         # Iterate through subject ranks
-        subject_rank = [named_rank_list(subjectcode=subject['subjectCode'],
-                        rank=subject['rank'],
-                        percentile=subject['percentile'])
+        subject_rank = [named_rank_list(subjectcode=int(subject['subjectCode']),
+                        rank=int(subject['rank']),
+                        percentile=int(subject['percentile']))
                         for subject in citeScoreInfo['citeScoreSubjectRank']]
         # Create named tuple with info
         Citescoreinfolist_year = named_info_list(year=int(d['@year']),

--- a/pybliometrics/scopus/serial_title.py
+++ b/pybliometrics/scopus/serial_title.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from typing import List, NamedTuple, Optional, Tuple, Union
 
 from pybliometrics.scopus.superclasses import Retrieval
-from pybliometrics.scopus.utils import chained_get, check_parameter_value, \
+from pybliometrics.scopus.utils import chained_get, check_parameter_value,\
     get_link, make_float_if_possible, make_int_if_possible
 
 
@@ -14,7 +14,8 @@ class SerialTitle(Retrieval):
 
     @property
     def citescoreyearinfolist(self) -> Optional[List[NamedTuple]]:
-        """A list of named tuples of the form `(year citescore status documentcount citationcount percentcited rank)`.
+        """A list of named tuples of the form:
+            `(year citescore status documentcount citationcount percentcited rank)`.
         For a complete extraction of the data use the [view]() `'CITESCORE'``. The named tuple contains the following fields:
         - `year`: Year
         - `status`: Year 'In-progress' or 'Complete'
@@ -35,21 +36,19 @@ class SerialTitle(Retrieval):
             return None
 
         # Named Tuples
-        info_fields = 'year citescore status documentcount '\
-            'citationcount percentcited '\
-            'rank'
+        info_fields = 'year citescore status documentcount citationcount percentcited rank'
         rank_fields = 'subjectcode rank percentile'
 
-        named_info_list = namedtuple(
-            'Citescoreinfolist', info_fields, defaults=(None,) * len(info_fields.split()))
+        named_info_list = namedtuple('Citescoreinfolist', info_fields,
+                                     defaults=(None,) * len(info_fields.split()))
         named_rank_list = namedtuple('Citescoresubjectrank', rank_fields)
 
         # Extract depending on view
         if self._view in ('STANDARD', 'ENHANCED'):
             new_data = _get_two_cite_score_years(self, named_info_list, data)
         elif self._view == 'CITESCORE':
-            new_data = _get_all_cite_score_years(
-                self, named_info_list, named_rank_list, data)
+            new_data = _get_all_cite_score_years(self, named_info_list,
+                                                 named_rank_list, data)
 
         return new_data or None
 
@@ -277,7 +276,8 @@ def _parse_list(d, metric):
 
 
 def _get_all_cite_score_years(self, named_info_list, named_rank_list, data) -> Optional[List[NamedTuple]]:
-    """Auxiliary function to get all information contained in cite score information list for the `CITESCORE` view"""
+    """Auxiliary function to get all information contained in cite score 
+    information list for the `CITESCORE` view."""
     data = data.get('citeScoreYearInfo', [])
 
     new_data = []
@@ -293,14 +293,10 @@ def _get_all_cite_score_years(self, named_info_list, named_rank_list, data) -> O
         # Create named tuple with info
         Citescoreinfolist_year = named_info_list(year=int(d['@year']),
                                                  status=d['@status'],
-                                                 documentcount=int(
-                                                     citeScoreInfo['scholarlyOutput']),
-                                                 citationcount=int(
-                                                     citeScoreInfo['citationCount']),
-                                                 citescore=make_float_if_possible(
-                                                     citeScoreInfo['citeScore']),
-                                                 percentcited=int(
-                                                     citeScoreInfo['percentCited']),
+                                                 documentcount=int(citeScoreInfo['scholarlyOutput']),
+                                                 citationcount=int(citeScoreInfo['citationCount']),
+                                                 citescore=make_float_if_possible(citeScoreInfo['citeScore']),
+                                                 percentcited=int(citeScoreInfo['percentCited']),
                                                  rank=subject_rank)
         # Append new data
         new_data.append(Citescoreinfolist_year)
@@ -309,7 +305,9 @@ def _get_all_cite_score_years(self, named_info_list, named_rank_list, data) -> O
 
 
 def _get_two_cite_score_years(self, named_info_list, data) -> Optional[List[NamedTuple]]:
-    """Auxiliary function to get information contained in cite score information list for the `STANDARD` and `ENHANCED` view"""
+    """Auxiliary function to get information contained in cite score information
+    list for the `STANDARD` and `ENHANCED` view.
+    """
 
     def create_namedtuple(data, mode, named_info_list):
         year = data.get(f'citeScore{mode}Year')

--- a/pybliometrics/scopus/serial_title.py
+++ b/pybliometrics/scopus/serial_title.py
@@ -11,37 +11,46 @@ class SerialTitle(Retrieval):
     def aggregation_type(self) -> str:
         """The type of the source."""
         return self._entry['prism:aggregationType']
-
+    
     @property
-    def citescoreyearinfolist(self) -> Optional[List[Tuple[int, float, None]]]:
-        """A list of two tuples of the form `(year, cite-score)`.  The first
-        tuple represents the current cite-score, the second tuple, if present,
-        represents the tracker cite-score.  For discontinued sources, there 
-        is no tracker cite-score, and the second tuple is just `None`.  See
-        https://service.elsevier.com/app/answers/detail/a_id/30562/supporthub/scopus/.
+    def citescoreyearinfolist(self) -> Optional[List[NamedTuple]]:
+        """A list of named tuples of the form `(year citescore status documentcount citationcount percentcited rank)`.\n
+        For a complete extraction of the data use the [view]() `'CITESCORE'``. The named tuple contains the following fields:
+        - `year`: Year
+        - `status`: Year 'In-progress' or 'Complete'
+        - `documentcount`: Number of documents of the last 4 years
+        - `citationcount`: Number of citations of the last 4 years
+        - `citescore`: citationCount/scholarlyOutput
+        - `percentcited`: Percent of documents cited
+        - `rank`: List of rank (and percentile) in different subjects
+
+        The `rank` is `None` or a named tuple of the form `(subjectcode rank percentile)`.
+
+        For more information check the [CiteScore documentation](https://service.elsevier.com/app/answers/detail/a_id/14880/supporthub/scopus/)
         """
-        def create_tuple(d, mode):
-            t = [d[f'citeScore{mode}Year'], d[f'citeScore{mode}']]
-            try:
-                t[0] = int(t[0])
-            except TypeError:  # year empty
-                return None
-            t[1] = float(t[1]) if t[1] else t[1]
-            return tuple(t)
+
 
         try:
-            d = self._entry['citeScoreYearInfoList']
+            data = self._entry.get('citeScoreYearInfoList', {})
         except KeyError:
             return None
-        try:
-            current = create_tuple(d, "CurrentMetric")
-        except KeyError:
-            current = None
-        try:
-            tracker = create_tuple(d, "CurrentTracker")
-        except KeyError:
-            tracker = None
-        return [current, tracker]
+        
+        # Named Tuples
+        info_fields = 'year citescore status documentcount '\
+                        'citationcount percentcited '\
+                        'rank'
+        rank_fields = 'subjectcode rank percentile'
+        
+        named_info_list = namedtuple('Citescoreinfolist', info_fields, defaults=(None,) * len(info_fields.split()))
+        named_rank_list = namedtuple('Citescoresubjectrank', rank_fields)
+            
+        # Extract depending on view
+        if self._view in ('STANDARD', 'ENHANCED'):
+                new_data = _getTwoCiteScoreYears(self, named_info_list, data)
+        elif self._view == 'CITESCORE':
+                new_data = _getAllCiteScoreYears(self, named_info_list, named_rank_list, data)
+                
+        return new_data or None
 
     @property
     def eissn(self) -> Optional[str]:
@@ -264,3 +273,46 @@ def _parse_list(d, metric):
         return sorted(set(values))
     except (KeyError, TypeError):
         return None
+    
+def _getAllCiteScoreYears(self, named_info_list, named_rank_list, data) -> Optional[List[NamedTuple]]:
+    data = data.get('citeScoreYearInfo', [])
+
+    new_data = []
+    # Iterate through years
+    for d in data:
+        citeScoreInfo = d.get('citeScoreInformationList', [])[0].get('citeScoreInfo', [])[0]
+        # Iterate through subject ranks
+        subject_rank = [named_rank_list(subjectcode=subject['subjectCode'],
+                        rank=subject['rank'],
+                        percentile=subject['percentile'])
+                        for subject in citeScoreInfo['citeScoreSubjectRank']]
+        # Create named tuple with info
+        Citescoreinfolist_year = named_info_list(year=int(d['@year']),
+                                status=d['@status'],
+                                documentcount=int(citeScoreInfo['scholarlyOutput']),
+                                citationcount=int(citeScoreInfo['citationCount']),
+                                citescore=make_float_if_possible(citeScoreInfo['citeScore']),
+                                percentcited=int(citeScoreInfo['percentCited']),
+                                rank=subject_rank)
+        # Append new data
+        new_data.append(Citescoreinfolist_year)
+    
+    return new_data or None
+
+def _getTwoCiteScoreYears(self, named_info_list, data) -> Optional[List[NamedTuple]]:
+    
+    def create_namedtuple(data, mode, named_info_list):
+        year = data.get(f'citeScore{mode}Year')
+        cite_score = data.get(f'citeScore{mode}')
+
+        # To be consistent with old verion
+        if (year is None) and (cite_score is None):
+            return None
+        else:
+            return named_info_list(year=int(year), citescore=float(cite_score))
+    
+    current = create_namedtuple(data, 'CurrentMetric', named_info_list)
+    tracker = create_namedtuple(data, 'CurrentTracker', named_info_list)
+    
+
+    return [current, tracker]

--- a/pybliometrics/scopus/superclasses/base.py
+++ b/pybliometrics/scopus/superclasses/base.py
@@ -47,7 +47,12 @@ class Base:
 
         # Read or download, possibly with caching
         fname = self._cache_file_path
+
+        # Check if search request
         search_request = "query" in params
+        # Chcek if ref retrieval for abstract
+        ab_all_ref_retrieval = (api == 'AbstractRetrieval') and (params['view'] == 'REF')
+
         if fname.exists() and not self._refresh:
             self._mdate = mod_ts
             if search_request:
@@ -59,7 +64,13 @@ class Base:
         else:
             resp = get_content(url, api, params, *args, **kwds)
             header = resp.headers
-            if search_request:
+
+            if ab_all_ref_retrieval:
+                kwds['startref'] = '1'
+                data = _get_all_refs(url, api, params, verbose, resp, *args, **kwds)
+                self._json = data
+                data = [data]
+            elif search_request:
                 # Get number of results
                 res = resp.json()
                 n = int(res['search-results'].get('opensearch:totalResults', 0))
@@ -154,3 +165,42 @@ def _check_file_age(self):
         refresh = True
         mod_ts = None
     return refresh, mod_ts
+
+def _get_references(res: dict) -> list:
+    """Get references list in responce"""
+    return res.get('abstracts-retrieval-response', {}).get('references', {}).get('reference', [])
+
+def _get_all_refs(url: str,
+                  api: str,
+                  params: dict,
+                  verbose: bool,
+                  resp: dict,
+                  *args, **kwds) -> dict:
+    """Get all references"""
+    # startref starts at 1 (0 does not work)
+    # Max refs per query are 40
+    # Use of refcount leads to errors
+    res = resp.json()
+    n = int(res.get('abstracts-retrieval-response', {}).get('references', {}).get('@total-references', 0))
+    
+    # Initialize data
+    data  = res
+
+    ref_len = len(_get_references(data))
+    n_chunks = ceil(n/ref_len)
+
+    for i in tqdm(range(1, n_chunks), disable=not verbose,
+                                  initial=1, total=n_chunks):
+        # Increment startref
+            kwds['startref'] = str(int(kwds['startref']) + ref_len)
+        # Get
+            resp = get_content(url, api, params, *args, **kwds)
+            res = resp.json()
+            tmp_data = _get_references(res)
+        # Append
+            data['abstracts-retrieval-response']['references']['reference'].extend(tmp_data)
+            if verbose: print(f'Extracted:\n\tFrom: {kwds["startref"]}\n\tTo:{len(_get_references(data))}')
+
+    if verbose: print(f'Total data: {len(_get_references(data))}')
+
+    return data

--- a/pybliometrics/scopus/superclasses/base.py
+++ b/pybliometrics/scopus/superclasses/base.py
@@ -6,7 +6,7 @@ from time import localtime, strftime, time
 from typing import Dict, Optional
 
 from pybliometrics.scopus.exception import ScopusQueryError
-from pybliometrics.scopus.utils import get_content, SEARCH_MAX_ENTRIES
+from pybliometrics.scopus.utils import get_content, SEARCH_MAX_ENTRIES, parse_content
 from tqdm import tqdm
 
 
@@ -50,8 +50,8 @@ class Base:
 
         # Check if search request
         search_request = "query" in params
-        # Chcek if ref retrieval for abstract
-        ab_all_ref_retrieval = (api == 'AbstractRetrieval') and (params['view'] == 'REF')
+        # Check if ref retrieval for abstract
+        ab_ref_retrieval = (api == 'AbstractRetrieval') and (params['view'] == 'REF')
 
         if fname.exists() and not self._refresh:
             self._mdate = mod_ts
@@ -65,7 +65,7 @@ class Base:
             resp = get_content(url, api, params, *args, **kwds)
             header = resp.headers
 
-            if ab_all_ref_retrieval:
+            if ab_ref_retrieval:
                 kwds['startref'] = '1'
                 data = _get_all_refs(url, api, params, verbose, resp, *args, **kwds)
                 self._json = data
@@ -166,9 +166,6 @@ def _check_file_age(self):
         mod_ts = None
     return refresh, mod_ts
 
-def _get_references(res: dict) -> list:
-    """Get references list in responce"""
-    return res.get('abstracts-retrieval-response', {}).get('references', {}).get('reference', [])
 
 def _get_all_refs(url: str,
                   api: str,
@@ -176,31 +173,37 @@ def _get_all_refs(url: str,
                   verbose: bool,
                   resp: dict,
                   *args, **kwds) -> dict:
-    """Get all references"""
+    """Get all references for `AbstractRetrieval` with view `REF`."""
     # startref starts at 1 (0 does not work)
     # Max refs per query are 40
     # Use of refcount leads to errors
     res = resp.json()
-    n = int(res.get('abstracts-retrieval-response', {}).get('references', {}).get('@total-references', 0))
-    
+    n = int(parse_content.chained_get(res, ['abstracts-retrieval-response',
+                                            'references',
+                                            '@total-references']))
+
     # Initialize data
     data  = res
 
-    ref_len = len(_get_references(data))
+    ref_len = len(parse_content.chained_get(data, ['abstracts-retrieval-response',
+                                                   'references',
+                                                   'reference']))
     n_chunks = ceil(n/ref_len)
 
     for i in tqdm(range(1, n_chunks), disable=not verbose,
                                   initial=1, total=n_chunks):
         # Increment startref
-            kwds['startref'] = str(int(kwds['startref']) + ref_len)
+        kwds['startref'] = str(int(kwds['startref']) + ref_len)
         # Get
-            resp = get_content(url, api, params, *args, **kwds)
-            res = resp.json()
-            tmp_data = _get_references(res)
+        resp = get_content(url, api, params, *args, **kwds)
+        res = resp.json()
+        res = parse_content.chained_get(res, ['abstracts-retrieval-response',
+                                              'references',
+                                              'reference'])
         # Append
-            data['abstracts-retrieval-response']['references']['reference'].extend(tmp_data)
-            if verbose: print(f'Extracted:\n\tFrom: {kwds["startref"]}\n\tTo:{len(_get_references(data))}')
+        data['abstracts-retrieval-response']['references']['reference'].extend(res)
+        if verbose: print(f'Extracted:\n\tFrom: {kwds["startref"]}\n\tTo:{len(parse_content.chained_get(data, ["abstracts-retrieval-response", "references", "reference"]))}')
 
-    if verbose: print(f'Total data: {len(_get_references(data))}')
+    if verbose: print(f'Total data: {len(parse_content.chained_get(data, ["abstracts-retrieval-response", "references", "reference"]))}')
 
     return data

--- a/pybliometrics/scopus/superclasses/base.py
+++ b/pybliometrics/scopus/superclasses/base.py
@@ -67,7 +67,7 @@ class Base:
 
             if ab_ref_retrieval:
                 kwds['startref'] = '1'
-                data = _get_all_refs(url, api, params, verbose, resp, *args, **kwds)
+                data = _get_all_refs(url, params, verbose, resp, *args, **kwds)
                 self._json = data
                 data = [data]
             elif search_request:
@@ -168,7 +168,6 @@ def _check_file_age(self):
 
 
 def _get_all_refs(url: str,
-                  api: str,
                   params: dict,
                   verbose: bool,
                   resp: dict,
@@ -195,7 +194,7 @@ def _get_all_refs(url: str,
         # Increment startref
         kwds['startref'] = str(int(kwds['startref']) + ref_len)
         # Get
-        resp = get_content(url, api, params, *args, **kwds)
+        resp = get_content(url, 'AbstractRetrieval', params, *args, **kwds)
         res = resp.json()
         res = parse_content.chained_get(res, ['abstracts-retrieval-response',
                                               'references',

--- a/pybliometrics/scopus/superclasses/base.py
+++ b/pybliometrics/scopus/superclasses/base.py
@@ -5,9 +5,10 @@ from math import ceil
 from time import localtime, strftime, time
 from typing import Dict, Optional
 
-from pybliometrics.scopus.exception import ScopusQueryError
-from pybliometrics.scopus.utils import get_content, SEARCH_MAX_ENTRIES, parse_content
 from tqdm import tqdm
+
+from pybliometrics.scopus.exception import ScopusQueryError
+from pybliometrics.scopus.utils import get_content, parse_content, SEARCH_MAX_ENTRIES
 
 
 class Base:
@@ -167,42 +168,35 @@ def _check_file_age(self):
     return refresh, mod_ts
 
 
-def _get_all_refs(url: str,
-                  params: dict,
-                  verbose: bool,
-                  resp: dict,
-                  *args, **kwds) -> dict:
+def _get_all_refs(url: str, params: dict, verbose: bool, resp: dict, *args, **kwds) -> dict:
     """Get all references for `AbstractRetrieval` with view `REF`."""
     # startref starts at 1 (0 does not work)
     # Max refs per query are 40
     # Use of refcount leads to errors
     res = resp.json()
-    n = int(parse_content.chained_get(res, ['abstracts-retrieval-response',
-                                            'references',
-                                            '@total-references']))
+    path_total_references = ['abstracts-retrieval-response', 'references', '@total-references']
+    n = int(parse_content.chained_get(res, path_total_references))
 
-    # Initialize data
-    data  = res
+    data  = res #data is used to gather all responses. res is a tmp variable
 
-    ref_len = len(parse_content.chained_get(data, ['abstracts-retrieval-response',
-                                                   'references',
-                                                   'reference']))
+    path_reference = ['abstracts-retrieval-response', 'references', 'reference']
+    ref_len = len(parse_content.chained_get(data, path_reference))
     n_chunks = ceil(n/ref_len)
 
     for i in tqdm(range(1, n_chunks), disable=not verbose,
-                                  initial=1, total=n_chunks):
+                  initial=1, total=n_chunks):
         # Increment startref
         kwds['startref'] = str(int(kwds['startref']) + ref_len)
         # Get
         resp = get_content(url, 'AbstractRetrieval', params, *args, **kwds)
         res = resp.json()
-        res = parse_content.chained_get(res, ['abstracts-retrieval-response',
-                                              'references',
-                                              'reference'])
+        res = parse_content.chained_get(res, path_reference)
         # Append
         data['abstracts-retrieval-response']['references']['reference'].extend(res)
-        if verbose: print(f'Extracted:\n\tFrom: {kwds["startref"]}\n\tTo:{len(parse_content.chained_get(data, ["abstracts-retrieval-response", "references", "reference"]))}')
+        if verbose:
+            print(f'Extracted:\n\tFrom: {kwds["startref"]}\n\tTo:{len(parse_content.chained_get(data, ["abstracts-retrieval-response", "references", "reference"]))}')
 
-    if verbose: print(f'Total data: {len(parse_content.chained_get(data, ["abstracts-retrieval-response", "references", "reference"]))}')
+    if verbose:
+        print(f'Total data: {len(parse_content.chained_get(data, ["abstracts-retrieval-response", "references", "reference"]))}')
 
     return data

--- a/pybliometrics/scopus/tests/test_AbstractRetrieval.py
+++ b/pybliometrics/scopus/tests/test_AbstractRetrieval.py
@@ -531,6 +531,7 @@ def test_website():
     assert_equal(ab2.website, None)
     assert_equal(ab8.website, None)
 
+
 def test_all_refs():
     refs_downloaded = len(ab8.references)
     expected = ab8.refcount

--- a/pybliometrics/scopus/tests/test_AbstractRetrieval.py
+++ b/pybliometrics/scopus/tests/test_AbstractRetrieval.py
@@ -530,3 +530,8 @@ def test_website():
     assert_equal(ab1.website, 'http://pubs.acs.org/page/accacs/about.html')
     assert_equal(ab2.website, None)
     assert_equal(ab8.website, None)
+
+def test_all_refs():
+    refs_downloaded = len(ab8.references)
+    expected = ab8.refcount
+    assert_equal(refs_downloaded, expected)

--- a/pybliometrics/scopus/tests/test_SerialTitle.py
+++ b/pybliometrics/scopus/tests/test_SerialTitle.py
@@ -31,7 +31,7 @@ def test_citescoreyearinfolist():
 
     # Test sofwarex
     expected_named_tuple = [named_info_list(year=2022, citescore=5.1), None]
-    assert_equal(expected_named_tuple, sofwarex.citescoreyearinfolist)
+    assert_equal(sofwarex.citescoreyearinfolist, expected_named_tuple)
 
     # Test oecd
     assert_equal(oecd.citescoreyearinfolist[0], None)

--- a/pybliometrics/scopus/tests/test_SerialTitle.py
+++ b/pybliometrics/scopus/tests/test_SerialTitle.py
@@ -2,12 +2,13 @@
 # -*- coding: utf-8 -*-
 """Tests for `scopus.SerialTitle` module."""
 
+import datetime
+
 from collections import namedtuple
 from nose.tools import assert_equal, assert_true
 
 from pybliometrics.scopus import SerialTitle
 
-import datetime
 
 # SoftwareX
 # sofwarex = SerialTitle("2352-7110", refresh=30, years="2019-2020")

--- a/pybliometrics/scopus/tests/test_SerialTitle.py
+++ b/pybliometrics/scopus/tests/test_SerialTitle.py
@@ -25,14 +25,15 @@ def test_aggregation_type():
 
 
 def test_citescoreyearinfolist():
-    expected_year = 2022
-    expected_citeScore = 5.1
-    expected_previous_year = None
+    info_fields = 'year citescore status documentcount citationcount percentcited rank'
+    named_info_list = namedtuple('Citescoreinfolist', info_fields,
+                                defaults=(None,) * len(info_fields.split()))
 
-    assert_equal(sofwarex.citescoreyearinfolist[0][0], expected_year)
-    assert_equal(sofwarex.citescoreyearinfolist[0][1], expected_citeScore)
-    assert_equal(sofwarex.citescoreyearinfolist[1], expected_previous_year)
+    # Test sofwarex
+    expected_named_tuple = [named_info_list(year=2022, citescore=5.1), None]
+    assert_equal(expected_named_tuple, sofwarex.citescoreyearinfolist)
 
+    # Test oecd
     assert_equal(oecd.citescoreyearinfolist[0], None)
     assert_equal(oecd.citescoreyearinfolist[1], None)
 

--- a/pybliometrics/scopus/tests/test_SerialTitle.py
+++ b/pybliometrics/scopus/tests/test_SerialTitle.py
@@ -7,11 +7,15 @@ from nose.tools import assert_equal, assert_true
 
 from pybliometrics.scopus import SerialTitle
 
+import datetime
+
 # SoftwareX
 # sofwarex = SerialTitle("2352-7110", refresh=30, years="2019-2020")
 sofwarex = SerialTitle("2352-7110", refresh=30)
 # OECD Economic Studies
 oecd = SerialTitle("0255-0822", refresh=30)
+# Neural Networks
+neural_networks = SerialTitle('1879-2782', view='CITESCORE')
 
 
 def test_aggregation_type():
@@ -20,9 +24,21 @@ def test_aggregation_type():
 
 
 def test_citescoreyearinfolist():
-    expected1 = [(2022, 5.1), None]
-    assert_equal(sofwarex.citescoreyearinfolist, expected1)
-    assert_equal(oecd.citescoreyearinfolist, None)
+    expected_year = 2022
+    expected_citeScore = 5.1
+    expected_previous_year = None
+
+    assert_equal(sofwarex.citescoreyearinfolist[0][0], expected_year)
+    assert_equal(sofwarex.citescoreyearinfolist[0][1], expected_citeScore)
+    assert_equal(sofwarex.citescoreyearinfolist[1], expected_previous_year)
+
+    assert_equal(oecd.citescoreyearinfolist[0], None)
+    assert_equal(oecd.citescoreyearinfolist[1], None)
+
+    # Test CITESCORE view
+    this_year = datetime.date.today().year
+    assert_equal(neural_networks.citescoreyearinfolist[0].year, this_year)
+    assert_true(type(neural_networks.citescoreyearinfolist[3].citationcount) is int)
 
 
 def test_eissn():


### PR DESCRIPTION
Previously, AbstractRetrieval with the REF view only queried and cached up to the default number of references (40). This version retrieves and caches all references.

Note: It may be desirable to parameterise the number of references to be downloaded, rather than the default of all.