### PR TITLE
#313 Fix AuthorRetrieval.affiliation_history

### DIFF
--- a/pybliometrics/scopus/author_retrieval.py
+++ b/pybliometrics/scopus/author_retrieval.py
@@ -44,8 +44,11 @@ class AuthorRetrieval(Retrieval):
         Note: Unlike on their website, Scopus doesn't provide the periods
         of affiliation.
         """
-        affs = chained_get(self._profile, ["affiliation-history", "affiliation"])
-        return parse_affiliation(affs)
+        if self._view in ('STANDARD', 'ENHANCED'):
+            affs = chained_get(self._profile, ["affiliation-history", "affiliation"])
+        else:
+            return None
+        return parse_affiliation(affs, self._view)
 
     @property
     def alias(self) -> Optional[List[str]]:


### PR DESCRIPTION
Minor bug caused by changes in #306 regarding the retrieval of current_affiliation