### PR TITLE
Feat 311: init() function to initialize the library.

### DIFF
--- a/pybliometrics/scopus/tests/test_AbstractRetrieval.py
+++ b/pybliometrics/scopus/tests/test_AbstractRetrieval.py
@@ -5,7 +5,9 @@
 from collections import namedtuple
 from nose.tools import assert_equal, assert_true
 
-from pybliometrics.scopus import AbstractRetrieval
+from pybliometrics.scopus import AbstractRetrieval, init
+
+init()
 
 # Base information
 ab1 = AbstractRetrieval("2-s2.0-84930616647", view="FULL", refresh=30)

--- a/pybliometrics/scopus/tests/test_AffiliationRetrieval.py
+++ b/pybliometrics/scopus/tests/test_AffiliationRetrieval.py
@@ -4,7 +4,9 @@
 
 from nose.tools import assert_equal, assert_true
 
-from pybliometrics.scopus import AffiliationRetrieval
+from pybliometrics.scopus import AffiliationRetrieval, init
+
+init()
 
 
 light = AffiliationRetrieval('60000356', refresh=30, view="LIGHT")

--- a/pybliometrics/scopus/tests/test_AffiliationSearch.py
+++ b/pybliometrics/scopus/tests/test_AffiliationSearch.py
@@ -6,7 +6,9 @@ from collections import namedtuple
 
 from nose.tools import assert_equal, assert_true
 
-from pybliometrics.scopus import AffiliationSearch
+from pybliometrics.scopus import AffiliationSearch, init
+
+init()
 
 s1 = AffiliationSearch('AF-ID(60021784)', refresh=30)
 s2 = AffiliationSearch('AFFIL(Max Planck Munich)', download=False, refresh=True)

--- a/pybliometrics/scopus/tests/test_AuthorRetrieval.py
+++ b/pybliometrics/scopus/tests/test_AuthorRetrieval.py
@@ -143,11 +143,12 @@ def test_eid():
 
 
 def test_estimate_uniqueness():
-    expected = 2
-    assert_equal(metrics.estimate_uniqueness(), 0)
-    assert_equal(light.estimate_uniqueness(), 0)
-    assert_equal(standard.estimate_uniqueness(), expected)
-    assert_equal(enhanced.estimate_uniqueness(), expected)
+    expected_1 = 2
+    expected_2 = 1
+    assert_equal(metrics.estimate_uniqueness(), expected_1)
+    assert_equal(light.estimate_uniqueness(), expected_1)
+    assert_equal(standard.estimate_uniqueness(), expected_2)
+    assert_equal(enhanced.estimate_uniqueness(), expected_2)
 
 
 def test_given_name():
@@ -176,7 +177,7 @@ def get_coauthors():
 def test_get_documents():
     subtypes = {'re', 'ed', 'no'}
     received = enhanced.get_documents(subtypes)
-    assert_equal(len(received), 7)
+    assert_equal(len(received), 8)
 
 
 def test_get_document_eids():

--- a/pybliometrics/scopus/tests/test_AuthorRetrieval.py
+++ b/pybliometrics/scopus/tests/test_AuthorRetrieval.py
@@ -143,12 +143,11 @@ def test_eid():
 
 
 def test_estimate_uniqueness():
-    expected_1 = 2
-    expected_2 = 1
-    assert_equal(metrics.estimate_uniqueness(), expected_1)
-    assert_equal(light.estimate_uniqueness(), expected_1)
-    assert_equal(standard.estimate_uniqueness(), expected_2)
-    assert_equal(enhanced.estimate_uniqueness(), expected_2)
+    expected = 2
+    assert_equal(metrics.estimate_uniqueness(), 0)
+    assert_equal(light.estimate_uniqueness(), 0)
+    assert_equal(standard.estimate_uniqueness(), expected)
+    assert_equal(enhanced.estimate_uniqueness(), expected)
 
 
 def test_given_name():
@@ -177,7 +176,7 @@ def get_coauthors():
 def test_get_documents():
     subtypes = {'re', 'ed', 'no'}
     received = enhanced.get_documents(subtypes)
-    assert_equal(len(received), 8)
+    assert_equal(len(received), 7)
 
 
 def test_get_document_eids():

--- a/pybliometrics/scopus/tests/test_AuthorRetrieval.py
+++ b/pybliometrics/scopus/tests/test_AuthorRetrieval.py
@@ -6,7 +6,9 @@ import warnings
 from collections import Counter, namedtuple
 from nose.tools import assert_equal, assert_true
 
-from pybliometrics.scopus import AuthorRetrieval
+from pybliometrics.scopus import AuthorRetrieval, init
+
+init()
 
 warnings.simplefilter("always")
 

--- a/pybliometrics/scopus/tests/test_AuthorSearch.py
+++ b/pybliometrics/scopus/tests/test_AuthorSearch.py
@@ -5,7 +5,9 @@
 from collections import namedtuple
 from nose.tools import assert_equal, assert_true
 
-from pybliometrics.scopus import AuthorSearch
+from pybliometrics.scopus import AuthorSearch, init
+
+init()
 
 s1 = AuthorSearch('authlast(selten) and authfirst(reinhard)', refresh=30)
 s2 = AuthorSearch('authlast(selten)', download=False, refresh=True)

--- a/pybliometrics/scopus/tests/test_CitationOverview.py
+++ b/pybliometrics/scopus/tests/test_CitationOverview.py
@@ -5,7 +5,9 @@
 from collections import namedtuple
 from nose.tools import assert_equal, assert_true
 
-from pybliometrics.scopus import CitationOverview
+from pybliometrics.scopus import CitationOverview, init
+
+init()
 
 
 co_eid = CitationOverview(["85068268027", "84930616647"],

--- a/pybliometrics/scopus/tests/test_PlumXMetrics.py
+++ b/pybliometrics/scopus/tests/test_PlumXMetrics.py
@@ -4,7 +4,9 @@
 
 from nose.tools import assert_equal, assert_true
 
-from pybliometrics.scopus import PlumXMetrics
+from pybliometrics.scopus import PlumXMetrics, init
+
+init()
 
 # A published paper. All PlumX Metrics categories are present.
 m1 = PlumXMetrics('2-s2.0-85054706190', 'elsevierId', refresh=30)

--- a/pybliometrics/scopus/tests/test_ScopusSearch.py
+++ b/pybliometrics/scopus/tests/test_ScopusSearch.py
@@ -6,7 +6,9 @@ from collections import namedtuple
 
 from nose.tools import assert_equal, assert_true
 
-from pybliometrics.scopus import ScopusSearch
+from pybliometrics.scopus import ScopusSearch, init
+
+init()
 
 order = 'eid doi pii pubmed_id title subtype subtypeDescription creator '\
         'afid affilname  affiliation_city affiliation_country author_count '\

--- a/pybliometrics/scopus/tests/test_SerialSearch.py
+++ b/pybliometrics/scopus/tests/test_SerialSearch.py
@@ -4,7 +4,9 @@
 
 from nose.tools import assert_equal, assert_true
 
-from pybliometrics.scopus import SerialSearch
+from pybliometrics.scopus import SerialSearch, init
+
+init()
 
 
 # Search by title

--- a/pybliometrics/scopus/tests/test_SerialTitle.py
+++ b/pybliometrics/scopus/tests/test_SerialTitle.py
@@ -32,7 +32,7 @@ def test_citescoreyearinfolist():
 
     # Test softwarex
     expected_named_tuple = [info(year=2022, citescore=5.1),
-                            info(year=2023, citescore=4.9)]
+                            info(year=2023, citescore=5.0)]
     assert_equal(softwarex.citescoreyearinfolist, expected_named_tuple)
 
     # Test oecd
@@ -155,7 +155,7 @@ def test_yearly_data():
     dat = namedtuple('Yearlydata', fields)
     expected1_2020 = dat(year=2020, publicationcount=164, revpercent=0.0,
         zerocitessce=10, zerocitespercentsce=6.097560975609756,
-        citecountsce=2571)
+        citecountsce=2570)
     assert_equal(softwarex.yearly_data[24], expected1_2020)
     expected2_1996 = dat(year=1996, publicationcount=4, revpercent=0.0,
         zerocitessce=0, zerocitespercentsce=0, citecountsce=33)

--- a/pybliometrics/scopus/tests/test_SerialTitle.py
+++ b/pybliometrics/scopus/tests/test_SerialTitle.py
@@ -32,7 +32,7 @@ def test_citescoreyearinfolist():
 
     # Test softwarex
     expected_named_tuple = [info(year=2022, citescore=5.1),
-                            info(year=2023, citescore=5.0)]
+                            info(year=2023, citescore=4.9)]
     assert_equal(softwarex.citescoreyearinfolist, expected_named_tuple)
 
     # Test oecd
@@ -155,7 +155,7 @@ def test_yearly_data():
     dat = namedtuple('Yearlydata', fields)
     expected1_2020 = dat(year=2020, publicationcount=164, revpercent=0.0,
         zerocitessce=10, zerocitespercentsce=6.097560975609756,
-        citecountsce=2570)
+        citecountsce=2571)
     assert_equal(softwarex.yearly_data[24], expected1_2020)
     expected2_1996 = dat(year=1996, publicationcount=4, revpercent=0.0,
         zerocitessce=0, zerocitespercentsce=0, citecountsce=33)

--- a/pybliometrics/scopus/tests/test_SerialTitle.py
+++ b/pybliometrics/scopus/tests/test_SerialTitle.py
@@ -7,7 +7,9 @@ import datetime
 from collections import namedtuple
 from nose.tools import assert_equal, assert_true
 
-from pybliometrics.scopus import SerialTitle
+from pybliometrics.scopus import SerialTitle, init
+
+init()
 
 
 # SoftwareX

--- a/pybliometrics/scopus/tests/test_SubjectClassifications.py
+++ b/pybliometrics/scopus/tests/test_SubjectClassifications.py
@@ -4,7 +4,9 @@
 
 from nose.tools import assert_equal, assert_true
 
-from pybliometrics.scopus import SubjectClassifications
+from pybliometrics.scopus import SubjectClassifications, init
+
+init()
 
 
 # Search by words in subject description

--- a/pybliometrics/scopus/utils/create_config.py
+++ b/pybliometrics/scopus/utils/create_config.py
@@ -2,7 +2,8 @@ import configparser
 from typing import List, Optional
 
 
-def create_config(keys: Optional[List[str]] = None,
+def create_config(config_dir: str,
+                  keys: Optional[List[str]] = None,
                   insttoken: Optional[str] = None
                   ):
     """Initiates process to generate configuration file.
@@ -13,11 +14,11 @@ def create_config(keys: Optional[List[str]] = None,
     :param insttoken: An InstToken to be used alongside the key(s).  Will only
                       be used if `keys` is not empty.
     """
-    from pybliometrics.scopus.utils.constants import CONFIG_FILE, DEFAULT_PATHS
+    from pybliometrics.scopus.utils.constants import DEFAULT_PATHS
 
     config = configparser.ConfigParser()
     config.optionxform = str
-    print(f"Creating config file at {CONFIG_FILE} with default paths...")
+    print(f"Creating config file at {config_dir} with default paths...")
 
     # Set directories
     config.add_section('Directories')
@@ -50,9 +51,9 @@ def create_config(keys: Optional[List[str]] = None,
     config.set('Requests', 'Retries', '5')
 
     # Write out
-    CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with open(CONFIG_FILE, "w") as ouf:
+    config_dir.parent.mkdir(parents=True, exist_ok=True)
+    with open(config_dir, "w") as ouf:
         config.write(ouf)
-    print(f"Configuration file successfully created at {CONFIG_FILE}\n"
+    print(f"Configuration file successfully created at {config_dir}\n"
           "For details see https://pybliometrics.rtfd.io/en/stable/configuration.html.")
     return config

--- a/pybliometrics/scopus/utils/create_config.py
+++ b/pybliometrics/scopus/utils/create_config.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 from pybliometrics.scopus.utils.constants import CONFIG_FILE
 
 
-def create_config(config_dir: Optional[str] = CONFIG_FILE,
+def create_config(config_dir: Optional[str] = None,
                   keys: Optional[List[str]] = None,
                   insttoken: Optional[str] = None
                   ):
@@ -16,6 +16,9 @@ def create_config(config_dir: Optional[str] = CONFIG_FILE,
                       be used if `keys` is not empty.
     """
     from pybliometrics.scopus.utils.constants import DEFAULT_PATHS
+
+    if not config_dir:
+        config_dir = CONFIG_FILE
 
     config = configparser.ConfigParser()
     config.optionxform = str

--- a/pybliometrics/scopus/utils/create_config.py
+++ b/pybliometrics/scopus/utils/create_config.py
@@ -1,8 +1,9 @@
 import configparser
 from typing import List, Optional
+from pybliometrics.scopus.utils.constants import CONFIG_FILE
 
 
-def create_config(config_dir: str,
+def create_config(config_dir: Optional[str] = CONFIG_FILE,
                   keys: Optional[List[str]] = None,
                   insttoken: Optional[str] = None
                   ):

--- a/pybliometrics/scopus/utils/get_content.py
+++ b/pybliometrics/scopus/utils/get_content.py
@@ -5,7 +5,7 @@ from urllib3.util import Retry
 
 from pybliometrics import __version__
 from pybliometrics.scopus import exception
-from pybliometrics.scopus.utils.startup import get_config,get_keys, get_throttling_params, get_config_path
+from pybliometrics.scopus.utils.startup import get_config, get_keys, get_throttling_params, get_config_path
 
 # Define user agent string for HTTP requests
 user_agent = 'pybliometrics-v' + __version__
@@ -179,10 +179,9 @@ def get_folder(api, view):
     config_path = get_config_path()
 
     if not config.has_section('Directories'):
-        raise FileNotFoundError(
-            'No configuration file found, please create one by initialize the scopus library with'
-            'init()'
-        )
+        error_message = 'No configuration file found, please create one by initializing the pybliometrics library '\
+            'with init()'
+        raise FileNotFoundError(error_message)
     try:
         parent = Path(config.get('Directories', api))
     except NoOptionError:

--- a/pybliometrics/scopus/utils/get_content.py
+++ b/pybliometrics/scopus/utils/get_content.py
@@ -177,10 +177,6 @@ def get_folder(api, view):
     config = get_config()
     config_path = get_config_path()
 
-    if not config.has_section('Directories'):
-        error_message = 'No configuration file found, please create one by initializing the pybliometrics library '\
-            'with init()'
-        raise FileNotFoundError(error_message)
     try:
         parent = Path(config.get('Directories', api))
     except NoOptionError:

--- a/pybliometrics/scopus/utils/get_content.py
+++ b/pybliometrics/scopus/utils/get_content.py
@@ -5,7 +5,7 @@ from urllib3.util import Retry
 
 from pybliometrics import __version__
 from pybliometrics.scopus import exception
-from pybliometrics.scopus.utils.startup import get_config, get_keys, get_throttling_params, get_config_path
+from pybliometrics.scopus.utils.startup import get_config, get_keys, get_config_path, _throttling_params
 
 # Define user agent string for HTTP requests
 user_agent = 'pybliometrics-v' + __version__
@@ -67,7 +67,6 @@ def get_content(url, api, params=None, **kwds):
 
     config = get_config()
     keys = get_keys()
-    throttling_params = get_throttling_params()
     session = get_session()
 
     # Set header, params and proxy
@@ -92,9 +91,9 @@ def get_content(url, api, params=None, **kwds):
         header['X-ELS-Insttoken'] = params.pop("insttoken")
 
     # Eventually wait bc of throttling
-    if len(throttling_params[api]) == throttling_params[api].maxlen:
+    if len(_throttling_params[api]) == _throttling_params[api].maxlen:
         try:
-            sleep(1 - (time() - throttling_params[api][0]))
+            sleep(1 - (time() - _throttling_params[api][0]))
         except (IndexError, ValueError):
             pass
 
@@ -111,7 +110,7 @@ def get_content(url, api, params=None, **kwds):
                                params=params, timeout=timeout)
         except IndexError:  # All keys depleted
             break
-    throttling_params[api].append(time())
+    _throttling_params[api].append(time())
 
     # Eventually raise error, if possible with supplied error message
     try:

--- a/pybliometrics/scopus/utils/get_content.py
+++ b/pybliometrics/scopus/utils/get_content.py
@@ -1,10 +1,11 @@
+from typing import Type
 from requests import Session
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
 from pybliometrics import __version__
 from pybliometrics.scopus import exception
-from pybliometrics.scopus.utils.startup import get_config, get_keys, get_throttling_params, get_config_path
+from pybliometrics.scopus.utils.startup import get_config,get_keys, get_throttling_params, get_config_path
 
 # Define user agent string for HTTP requests
 user_agent = 'pybliometrics-v' + __version__
@@ -14,7 +15,8 @@ errors = {400: exception.Scopus400Error, 401: exception.Scopus401Error,
           407: exception.Scopus407Error, 413: exception.Scopus413Error, 
           414: exception.Scopus414Error, 429: exception.Scopus429Error}
 
-def get_session():
+def get_session() -> Type[Session]:
+    """Auxiliary function to create a session"""
     config = get_config()
 
     _retries = config.getint("Requests", "Retries", fallback=5)
@@ -24,7 +26,7 @@ def get_session():
     session = Session()
     session.mount('http://', adapter)
     session.mount('https://', adapter)
-    
+
     return session
 
 def get_content(url, api, params=None, **kwds):
@@ -95,7 +97,7 @@ def get_content(url, api, params=None, **kwds):
             sleep(1 - (time() - throttling_params[api][0]))
         except (IndexError, ValueError):
             pass
-    
+
     # Perform request, eventually replacing the current key
     timeout = config.getint("Requests", "Timeout", fallback=20)
     resp = session.get(url, headers=header, proxies=proxies, params=params,
@@ -172,15 +174,15 @@ def get_folder(api, view):
     from pathlib import Path
 
     from pybliometrics.scopus.utils import DEFAULT_PATHS
-    from pybliometrics.scopus.utils.create_config import create_config
 
     config = get_config()
     config_path = get_config_path()
 
     if not config.has_section('Directories'):
         raise FileNotFoundError(
-            'No configuration file found, please create one by initialize the scopus library with init()'
-            )
+            'No configuration file found, please create one by initialize the scopus library with'
+            'init()'
+        )
     try:
         parent = Path(config.get('Directories', api))
     except NoOptionError:

--- a/pybliometrics/scopus/utils/startup.py
+++ b/pybliometrics/scopus/utils/startup.py
@@ -1,21 +1,72 @@
-import configparser
+from configparser import ConfigParser
 from collections import deque
 from pathlib import Path
+from typing import List, Dict, Optional, Type
+from os import path
+from warnings import warn
 
 from pybliometrics.scopus.utils.constants import CONFIG_FILE, RATELIMITS
 from pybliometrics.scopus.utils.create_config import create_config
 
-# Read/create config file (with fixture for RTFD.io)
-config = configparser.ConfigParser()
-config.optionxform = str
-try:
-    if not CONFIG_FILE.exists():
-        config = create_config()
-    else:
-        config.read(CONFIG_FILE)
-    KEYS = [k.strip() for k in config.get('Authentication', 'APIKey').split(",")]
-except EOFError:
-    pass
+_custom_config_dir = None
+_custom_keys = None
 
-# Throttling params
-_throttling_params = {k: deque(maxlen=v) for k, v in RATELIMITS.items()}
+def get_config() -> Type[ConfigParser]:
+    """Auxiliary function to get the config parser"""
+    # Read/create config file (with fixture for RTFD.io)
+    config = ConfigParser()
+    config.optionxform = str
+
+    if not _custom_config_dir and not CONFIG_FILE.exists():
+            warn('Please create a configuration file by initializing Scopus with init().\n'
+                 'For more information visit: https://pybliometrics.readthedocs.io/en/stable/configuration.html')
+    else:
+        if _custom_config_dir:
+            config.read(_custom_config_dir)
+        else:
+            warn('Please initialize Scopus with init()', FutureWarning)
+            config.read(CONFIG_FILE)
+    
+    return config
+
+def get_config_path() -> Type[Path]:
+    """Auxiliary function to get the configuration file path"""
+    return _custom_config_dir or CONFIG_FILE
+
+def get_keys() -> List[str]:
+    """Auxiliary function to get the API keys"""
+    if _custom_keys:
+        keys = _custom_keys
+    else:
+        config = get_config()
+        keys = [k.strip() for k in config.get('Authentication', 'APIKey').split(",")]
+    return keys
+
+def get_throttling_params() -> Dict:
+    """Auxiliary function to get the throttling params"""
+    return {k: deque(maxlen=v) for k, v in RATELIMITS.items()}
+
+def init(config_dir: Optional[str] = CONFIG_FILE, keys: Optional[List[str]] = None) -> None:
+    """
+    Function to initialize the Pybliometrics library. For more information go to the [documentation](https://pybliometrics.readthedocs.io/en/stable/configuration.html).
+    
+    Parameters
+    ----------
+    config_dir : str
+        Path to the configuration file
+    keys : lst
+        List of API keys
+    """
+    global _custom_config_dir
+    global _custom_keys
+
+    config_dir = Path(config_dir)
+
+    if not config_dir.exists():
+        create_config(config_dir,
+                      keys)
+    
+    _custom_config_dir = config_dir
+    _custom_keys = keys
+
+    return None

--- a/pybliometrics/scopus/utils/startup.py
+++ b/pybliometrics/scopus/utils/startup.py
@@ -1,51 +1,16 @@
-import os
-from configparser import ConfigParser
+from configparser import ConfigParser, NoSectionError
 from collections import deque
 from pathlib import Path
-from typing import List, Dict, Optional, Type
-from warnings import warn
+from typing import List, Optional, Type
 
 from pybliometrics.scopus.utils.constants import CONFIG_FILE, RATELIMITS
 from pybliometrics.scopus.utils.create_config import create_config
 
-CUSTOM_DIR = None
+CONFIG = None
+CONFIG_DIR = None
 CUSTOM_KEYS = None
 
 _throttling_params = {k: deque(maxlen=v) for k, v in RATELIMITS.items()}
-
-def get_config() -> Type[ConfigParser]:
-    """Auxiliary function to get the config parser"""
-    # Read/create config file (with fixture for RTFD.io)
-    config = ConfigParser()
-    config.optionxform = str
-
-    if not CUSTOM_DIR and not CONFIG_FILE.exists():
-        warn('Please create a configuration file by initializing Pybliometrics with init().\n'
-             'For more information visit: '
-             'https://pybliometrics.readthedocs.io/en/stable/configuration.html')
-    else:
-        if CUSTOM_DIR:
-            config.read(CUSTOM_DIR)
-        else:
-            warn('Please initialize Pybliometrics with init().\n'
-                 'For more information visit: '
-                 'https://pybliometrics.readthedocs.io/en/stable/configuration.html', FutureWarning)
-            config.read(CONFIG_FILE)
-
-    return config
-
-def get_config_path() -> Type[Path]:
-    """Auxiliary function to get the configuration file path"""
-    return CUSTOM_DIR or CONFIG_FILE
-
-def get_keys() -> List[str]:
-    """Auxiliary function to get the API keys"""
-    if CUSTOM_KEYS:
-        keys = CUSTOM_KEYS
-    else:
-        config = get_config()
-        keys = [k.strip() for k in config.get('Authentication', 'APIKey').split(",")]
-    return keys
 
 def init(config_dir: Optional[str] = CONFIG_FILE, keys: Optional[List[str]] = None) -> None:
     """
@@ -59,14 +24,52 @@ def init(config_dir: Optional[str] = CONFIG_FILE, keys: Optional[List[str]] = No
     keys : lst
         List of API keys
     """
-    global CUSTOM_DIR
+    global CONFIG
     global CUSTOM_KEYS
+    global CONFIG_DIR
 
     config_dir = Path(config_dir)
 
     if not config_dir.exists():
-        create_config(config_dir,
-                      keys)
+        CONFIG = create_config(config_dir,
+                               keys)
+    else:
+        CONFIG = ConfigParser()
+        CONFIG.optionxform = str
+        CONFIG.read(config_dir)
 
-    CUSTOM_DIR = config_dir
+    check_sections(CONFIG)
+
     CUSTOM_KEYS = keys
+    CONFIG_DIR = config_dir
+
+
+def check_sections(config: Type[ConfigParser]) -> None:
+    """Auxiliary function to check if all sections exist."""
+    for section in ['Directories', 'Authentication', 'Requests']:
+        if not config.has_section(section):
+            raise NoSectionError(section)
+
+
+def get_config() -> Type[ConfigParser]:
+    """Function to get the config parser."""
+    if not CONFIG:
+        raise FileNotFoundError('No configuration file found.'
+                                'Please initialize Pybliometrics with init().\n'
+                                'For more information visit: '
+                                'https://pybliometrics.readthedocs.io/en/stable/configuration.html')
+    return CONFIG
+
+
+def get_config_path() -> Type[Path]:
+    """Function to get the configuration file path."""
+    return CONFIG_DIR or CONFIG_FILE
+
+
+def get_keys() -> List[str]:
+    """Function to get the API keys and overwrite keys in config if needed."""
+    if CUSTOM_KEYS:
+        keys = CUSTOM_KEYS
+    else:
+        keys = [k.strip() for k in CONFIG.get('Authentication', 'APIKey').split(",")]
+    return keys

--- a/pybliometrics/scopus/utils/startup.py
+++ b/pybliometrics/scopus/utils/startup.py
@@ -1,8 +1,8 @@
+import os
 from configparser import ConfigParser
 from collections import deque
 from pathlib import Path
 from typing import List, Dict, Optional, Type
-import os
 from warnings import warn
 
 from pybliometrics.scopus.utils.constants import CONFIG_FILE, RATELIMITS
@@ -18,14 +18,14 @@ def get_config() -> Type[ConfigParser]:
     config.optionxform = str
 
     if not CUSTOM_DIR and not CONFIG_FILE.exists():
-        warn('Please create a configuration file by initializing Scopus with init().\n'
+        warn('Please create a configuration file by initializing Pybliometrics with init().\n'
              'For more information visit: '
              'https://pybliometrics.readthedocs.io/en/stable/configuration.html')
     else:
         if CUSTOM_DIR:
             config.read(CUSTOM_DIR)
         else:
-            warn('Please initialize Scopus with init().\n'
+            warn('Please initialize Pybliometrics with init().\n'
                  'For more information visit: '
                  'https://pybliometrics.readthedocs.io/en/stable/configuration.html', FutureWarning)
             config.read(CONFIG_FILE)

--- a/pybliometrics/scopus/utils/startup.py
+++ b/pybliometrics/scopus/utils/startup.py
@@ -63,7 +63,6 @@ def init(config_dir: Optional[str] = CONFIG_FILE, keys: Optional[List[str]] = No
     global CUSTOM_KEYS
 
     config_dir = Path(config_dir)
-    config_dir = _change_folder_path(config_dir)
 
     if not config_dir.exists():
         create_config(config_dir,
@@ -71,9 +70,3 @@ def init(config_dir: Optional[str] = CONFIG_FILE, keys: Optional[List[str]] = No
 
     CUSTOM_DIR = config_dir
     CUSTOM_KEYS = keys
-
-def _change_folder_path(path: Type[Path], default_filename: str='pybliometrics.cfg') -> Type[Path]:
-    """Auxiliary function to correct the path for a folder"""
-    if os.path.isdir(path):
-        return path/default_filename
-    return path

--- a/pybliometrics/scopus/utils/startup.py
+++ b/pybliometrics/scopus/utils/startup.py
@@ -11,6 +11,8 @@ from pybliometrics.scopus.utils.create_config import create_config
 CUSTOM_DIR = None
 CUSTOM_KEYS = None
 
+_throttling_params = {k: deque(maxlen=v) for k, v in RATELIMITS.items()}
+
 def get_config() -> Type[ConfigParser]:
     """Auxiliary function to get the config parser"""
     # Read/create config file (with fixture for RTFD.io)
@@ -44,10 +46,6 @@ def get_keys() -> List[str]:
         config = get_config()
         keys = [k.strip() for k in config.get('Authentication', 'APIKey').split(",")]
     return keys
-
-def get_throttling_params() -> Dict:
-    """Auxiliary function to get the throttling params"""
-    return {k: deque(maxlen=v) for k, v in RATELIMITS.items()}
 
 def init(config_dir: Optional[str] = CONFIG_FILE, keys: Optional[List[str]] = None) -> None:
     """

--- a/pybliometrics/scopus/utils/startup.py
+++ b/pybliometrics/scopus/utils/startup.py
@@ -24,7 +24,8 @@ def get_config() -> Type[ConfigParser]:
         if _custom_config_dir:
             config.read(_custom_config_dir)
         else:
-            warn('Please initialize Scopus with init()', FutureWarning)
+            warn('Please initialize Scopus with init().\n'
+                 'For more information visit: https://pybliometrics.readthedocs.io/en/stable/configuration.html', FutureWarning)
             config.read(CONFIG_FILE)
     
     return config


### PR DESCRIPTION
This feature implements a new initialization pipeline by implementing the `init()` function. The new code logic can be found in the startup.py file. Here is an example:
```python
from pybliometrics.scopus import *
init('/Users/user/.config/pybiliometrics.cfg',
     ['abc', 'def', 'ghi'])
ar = AbstractRetrieval('10.1016/j.sigpro.2023.109309')
```
here is another:
```python
from pybliometrics.scopus import AbstractRetrieval, init
init()
ar = AbstractRetrieval('S0049089X1200097X')
```

The feature handles two scenarios in case no `init()` is called:
1. A config file exists in one of the default directories (Old users): A warning is raised and the library works normally
2. No config file exists: A `FileNotFoundError` is raised with the message `No configuration file found, please create one by initialize the scopus library with init()`

The feature handles three scenarios in case the `init()` is called:
1. If the config file exists nothing is done
2. If the config file does not exist it is created (with the keys)
3. If a config file exists but another directory or keys are provided it gets overwritten

Some To-Do's after the code review:
- [ ] Update the documentation