### PR TITLE
#316 Get cache folder functionality was moved to startup

### DIFF
--- a/pybliometrics/scopus/subject_classifications.py
+++ b/pybliometrics/scopus/subject_classifications.py
@@ -88,7 +88,7 @@ class SubjectClassifications(Search):
         query['field'] = ','.join(self.fields)
         self._refresh = refresh
         self._query = str(query)
-        self._view = None
+        self._view = ''
         Search.__init__(self, query=query, api='SubjectClassifications', **kwds)
         path = ['subject-classifications', 'subject-classification']
         self._n = len(chained_get(self._json, path, []))

--- a/pybliometrics/scopus/superclasses/retrieval.py
+++ b/pybliometrics/scopus/superclasses/retrieval.py
@@ -1,9 +1,10 @@
 """Superclass to access all Scopus retrieval APIs and dump the results."""
 
+from pathlib import Path
 from typing import Union
 
 from pybliometrics.scopus.superclasses import Base
-from pybliometrics.scopus.utils import get_folder, URLS
+from pybliometrics.scopus.utils import get_config, URLS
 
 
 class Retrieval(Base):
@@ -41,7 +42,11 @@ class Retrieval(Base):
         else:
             url += identifier
             stem = identifier.replace('/', '_')
-        self._cache_file_path = get_folder(api, self._view)/stem
+        # Get cache file path
+        self._view = self._view or ''
+        config = get_config()
+        parent = Path(config.get('Directories', api))
+        self._cache_file_path = parent/self._view/stem
 
         # Parse file contents
         params = {'view': self._view, **kwds}

--- a/pybliometrics/scopus/superclasses/retrieval.py
+++ b/pybliometrics/scopus/superclasses/retrieval.py
@@ -43,7 +43,6 @@ class Retrieval(Base):
             url += identifier
             stem = identifier.replace('/', '_')
         # Get cache file path
-        self._view = self._view or ''
         config = get_config()
         parent = Path(config.get('Directories', api))
         self._cache_file_path = parent/self._view/stem

--- a/pybliometrics/scopus/superclasses/search.py
+++ b/pybliometrics/scopus/superclasses/search.py
@@ -58,7 +58,6 @@ class Search(Base):
         # Construct cache file path
         stem = md5(name.encode('utf8')).hexdigest()
         # Get cache file path
-        self._view = self._view or ''
         config = get_config()
         parent = Path(config.get('Directories', api))
         self._cache_file_path = parent/self._view/stem

--- a/pybliometrics/scopus/superclasses/search.py
+++ b/pybliometrics/scopus/superclasses/search.py
@@ -1,9 +1,10 @@
 """Superclass to access all Scopus search APIs and dump the results."""
 
 from hashlib import md5
+from pathlib import Path
 
 from pybliometrics.scopus.superclasses import Base
-from pybliometrics.scopus.utils import get_folder, URLS
+from pybliometrics.scopus.utils import get_config, URLS
 
 
 class Search(Base):
@@ -56,7 +57,11 @@ class Search(Base):
 
         # Construct cache file path
         stem = md5(name.encode('utf8')).hexdigest()
-        self._cache_file_path = get_folder(api, self._view)/stem
+        # Get cache file path
+        self._view = self._view or ''
+        config = get_config()
+        parent = Path(config.get('Directories', api))
+        self._cache_file_path = parent/self._view/stem
 
         # Init
         Base.__init__(self, params=params, url=URLS[api], download=download,

--- a/pybliometrics/scopus/utils/constants.py
+++ b/pybliometrics/scopus/utils/constants.py
@@ -50,6 +50,21 @@ URLS = {
     'PlumXMetrics': 'https://api.elsevier.com/analytics/plumx/'
 }
 
+# Valid views for all classes
+VIEWS = {
+    "CitationOverview": ["STANDARD"],
+    "AbstractRetrieval": ["META", "META_ABS", "FULL", "REF", "ENTITLED"],
+    "AffiliationRetrieval": ["LIGHT", "STANDARD", "ENTITLED"],
+    "AffiliationSearch": ["STANDARD"],
+    "AuthorRetrieval": ["LIGHT", "STANDARD", "ENHANCED", "METRICS", "ENTITLED"],
+    "AuthorSearch": ["STANDARD"],
+    "PlumXMetrics": ["ENHANCED"],
+    "ScopusSearch": ["STANDARD", "COMPLETE"],
+    "SerialSearch": ["STANDARD", "ENHANCED", "CITESCORE"],
+    "SerialTitle": ["STANDARD", "ENHANCED", "CITESCORE"],
+    "SubjectClassifications": [''],
+}
+
 # Throttling limits (in queries per second) // 0 = no limit
 RATELIMITS = {
     'AbstractRetrieval': 9,

--- a/pybliometrics/scopus/utils/get_content.py
+++ b/pybliometrics/scopus/utils/get_content.py
@@ -5,7 +5,7 @@ from urllib3.util import Retry
 
 from pybliometrics import __version__
 from pybliometrics.scopus import exception
-from pybliometrics.scopus.utils.startup import get_config, get_keys, get_config_path, _throttling_params
+from pybliometrics.scopus.utils.startup import get_config, get_keys, _throttling_params
 
 # Define user agent string for HTTP requests
 user_agent = 'pybliometrics-v' + __version__
@@ -163,30 +163,3 @@ def detect_id_type(sid):
         return id_type
     except UnboundLocalError:
         raise ValueError(f'ID type detection failed for "{sid}".')
-
-
-def get_folder(api, view):
-    """Auxiliary function to get the cache folder belonging to an API,
-    eventually create the folder.
-    """
-    from configparser import NoOptionError
-    from pathlib import Path
-
-    from pybliometrics.scopus.utils import DEFAULT_PATHS
-
-    config = get_config()
-    config_path = get_config_path()
-
-    try:
-        parent = Path(config.get('Directories', api))
-    except NoOptionError:
-        parent = DEFAULT_PATHS[api]
-        config.set('Directories', api, str(parent))
-        with open(config_path, 'w') as ouf:
-            config.write(ouf)
-    try:
-        folder = parent/view
-    except TypeError:
-        folder = parent
-    folder.mkdir(parents=True, exist_ok=True)
-    return folder

--- a/pybliometrics/scopus/utils/startup.py
+++ b/pybliometrics/scopus/utils/startup.py
@@ -56,6 +56,7 @@ def check_default_paths(config: Type[ConfigParser], config_path: Type[Path]) -> 
             config.set('Directories', api, str(path))
             with open(config_path, 'w', encoding='utf-8') as ouf:
                 config.write(ouf)
+        path.mkdir(parents=True, exist_ok=True)
 
 def get_config() -> Type[ConfigParser]:
     """Function to get the config parser."""

--- a/pybliometrics/scopus/utils/startup.py
+++ b/pybliometrics/scopus/utils/startup.py
@@ -3,7 +3,7 @@ from collections import deque
 from pathlib import Path
 from typing import List, Optional, Type
 
-from pybliometrics.scopus.utils.constants import CONFIG_FILE, RATELIMITS, DEFAULT_PATHS
+from pybliometrics.scopus.utils.constants import CONFIG_FILE, RATELIMITS, DEFAULT_PATHS, VIEWS
 from pybliometrics.scopus.utils.create_config import create_config
 
 CONFIG = None
@@ -56,7 +56,9 @@ def check_default_paths(config: Type[ConfigParser], config_path: Type[Path]) -> 
             config.set('Directories', api, str(path))
             with open(config_path, 'w', encoding='utf-8') as ouf:
                 config.write(ouf)
-        path.mkdir(parents=True, exist_ok=True)
+        for view in VIEWS[api]:
+            view_path = path/view
+            view_path.mkdir(parents=True, exist_ok=True)
 
 def get_config() -> Type[ConfigParser]:
     """Function to get the config parser."""
@@ -75,15 +77,3 @@ def get_keys() -> List[str]:
         keys = [k.strip() for k in CONFIG.get('Authentication', 'APIKey').split(",")]
     return keys
 
-def get_folder(api, view):
-    """Auxiliary function to get the cache folder belonging to an API,
-    eventually create the folder.
-    """
-    parent = Path(CONFIG.get('Directories', api))
-    # Create folder if it does not exist
-    try:
-        folder = parent/view
-    except TypeError:
-        folder = parent
-    folder.mkdir(parents=True, exist_ok=True)
-    return folder

--- a/pybliometrics/scopus/utils/startup.py
+++ b/pybliometrics/scopus/utils/startup.py
@@ -3,11 +3,10 @@ from collections import deque
 from pathlib import Path
 from typing import List, Optional, Type
 
-from pybliometrics.scopus.utils.constants import CONFIG_FILE, RATELIMITS
+from pybliometrics.scopus.utils.constants import CONFIG_FILE, RATELIMITS, DEFAULT_PATHS
 from pybliometrics.scopus.utils.create_config import create_config
 
 CONFIG = None
-CONFIG_DIR = None
 CUSTOM_KEYS = None
 
 _throttling_params = {k: deque(maxlen=v) for k, v in RATELIMITS.items()}
@@ -26,7 +25,6 @@ def init(config_dir: Optional[str] = CONFIG_FILE, keys: Optional[List[str]] = No
     """
     global CONFIG
     global CUSTOM_KEYS
-    global CONFIG_DIR
 
     config_dir = Path(config_dir)
 
@@ -39,9 +37,9 @@ def init(config_dir: Optional[str] = CONFIG_FILE, keys: Optional[List[str]] = No
         CONFIG.read(config_dir)
 
     check_sections(CONFIG)
+    check_default_paths(CONFIG, config_dir)
 
     CUSTOM_KEYS = keys
-    CONFIG_DIR = config_dir
 
 
 def check_sections(config: Type[ConfigParser]) -> None:
@@ -50,6 +48,14 @@ def check_sections(config: Type[ConfigParser]) -> None:
         if not config.has_section(section):
             raise NoSectionError(section)
 
+def check_default_paths(config: Type[ConfigParser], config_path: Type[Path]) -> None:
+    """Auxiliary function to check if default cache paths exist.
+    If not, the paths are writen in the config"""
+    for api, path in DEFAULT_PATHS.items():
+        if not config.has_option('Directories', api):
+            config.set('Directories', api, str(path))
+            with open(config_path, 'w', encoding='utf-8') as ouf:
+                config.write(ouf)
 
 def get_config() -> Type[ConfigParser]:
     """Function to get the config parser."""
@@ -60,12 +66,6 @@ def get_config() -> Type[ConfigParser]:
                                 'https://pybliometrics.readthedocs.io/en/stable/configuration.html')
     return CONFIG
 
-
-def get_config_path() -> Type[Path]:
-    """Function to get the configuration file path."""
-    return CONFIG_DIR or CONFIG_FILE
-
-
 def get_keys() -> List[str]:
     """Function to get the API keys and overwrite keys in config if needed."""
     if CUSTOM_KEYS:
@@ -73,3 +73,16 @@ def get_keys() -> List[str]:
     else:
         keys = [k.strip() for k in CONFIG.get('Authentication', 'APIKey').split(",")]
     return keys
+
+def get_folder(api, view):
+    """Auxiliary function to get the cache folder belonging to an API,
+    eventually create the folder.
+    """
+    parent = Path(CONFIG.get('Directories', api))
+    # Create folder if it does not exist
+    try:
+        folder = parent/view
+    except TypeError:
+        folder = parent
+    folder.mkdir(parents=True, exist_ok=True)
+    return folder


### PR DESCRIPTION
Get cache folder functionality was moved to the `startup.py` file. The `init()` function checks if all paths needed are in the config file, if not, the missing paths are added.