### PR TITLE
Bug 327

### DIFF
--- a/pybliometrics/scopus/abstract_retrieval.py
+++ b/pybliometrics/scopus/abstract_retrieval.py
@@ -799,16 +799,19 @@ class AbstractRetrieval(Retrieval):
                 s += '\n   '.join([aff.name for aff in self.affiliation])
         
         elif self._view in ('REF'):
-            # Sort reference list by citationcount
-            top_n = 5
-            references = sorted(self.references, key=convert_citedbycount, reverse=True)
+            try:
+                # Sort reference list by citationcount
+                top_n = 5
+                references = sorted(self.references, key=convert_citedbycount, reverse=True)
 
-            top_references = [f'{reference.title} ({get_date(reference.coverDate)}). '+
-                              f'EID: {reference.id}' for reference in references[:top_n]]
+                top_references = [f'{reference.title} ({get_date(reference.coverDate)}). '+
+                                f'EID: {reference.id}' for reference in references[:top_n]]
 
-            s = f'A total of {self.refcount} references were found. '
-            s += f'Top {top_n} references:\n\t'
-            s += '\n\t'.join(top_references)
+                s = f'A total of {self.refcount} references were found. '
+                s += f'Top {top_n} references:\n\t'
+                s += '\n\t'.join(top_references)
+            except TypeError:
+                s = 'No references found'
 
         return s
 

--- a/pybliometrics/scopus/abstract_retrieval.py
+++ b/pybliometrics/scopus/abstract_retrieval.py
@@ -806,12 +806,13 @@ class AbstractRetrieval(Retrieval):
 
                 top_references = [f'{reference.title} ({get_date(reference.coverDate)}). '+
                                 f'EID: {reference.id}' for reference in references[:top_n]]
+            except TypeError:
+                top_n = 0
 
-                s = f'A total of {self.refcount} references were found. '
+            s = f'A total of {self.refcount or 0} references were found. '
+            if top_n:
                 s += f'Top {top_n} references:\n\t'
                 s += '\n\t'.join(top_references)
-            except TypeError:
-                s = 'No references found'
 
         return s
 

--- a/pybliometrics/scopus/superclasses/base.py
+++ b/pybliometrics/scopus/superclasses/base.py
@@ -175,7 +175,10 @@ def _get_all_refs(url: str, params: dict, verbose: bool, resp: dict, *args, **kw
     # Use of refcount leads to errors
     res = resp.json()
     path_total_references = ['abstracts-retrieval-response', 'references', '@total-references']
-    n = int(parse_content.chained_get(res, path_total_references))
+    try:
+        n = int(parse_content.chained_get(res, path_total_references))
+    except TypeError:
+        return res
 
     data  = res #data is used to gather all responses. res is a tmp variable
 

--- a/pybliometrics/scopus/tests/test_AbstractRetrieval.py
+++ b/pybliometrics/scopus/tests/test_AbstractRetrieval.py
@@ -26,6 +26,8 @@ ab8 = AbstractRetrieval("2-s2.0-84951753303", view="REF", refresh=30)
 ab9 = AbstractRetrieval("2-s2.0-85097473741", view="FULL", refresh=30)
 # ENTITLED view
 ar10 = AbstractRetrieval('10.1109/Multi-Temp.2019.8866947', view='ENTITLED', refresh=30)
+# REF view without refs
+ab11 = AbstractRetrieval('2-s2.0-0031874638', view="REF", refresh=True)
 
 
 def test_abstract():
@@ -399,6 +401,7 @@ def test_pubmed_id():
 def test_refcount():
     assert ab4.refcount == 18
     assert ab8.refcount == 48
+    assert ab11.refcount is None
 
 
 def test_references_full():
@@ -442,6 +445,7 @@ def test_references_ref():
         first=None, last=None, citedbycount='0', type='resolvedReference')
     assert ab8.references[-2]._replace(citedbycount="0") == expected8
     assert int(ab8.references[-2].citedbycount) >= 0
+    assert ab11.references is None
 
 
 def test_scopus_link():

--- a/pybliometrics/scopus/tests/test_AbstractRetrieval.py
+++ b/pybliometrics/scopus/tests/test_AbstractRetrieval.py
@@ -27,7 +27,7 @@ ab9 = AbstractRetrieval("2-s2.0-85097473741", view="FULL", refresh=30)
 # ENTITLED view
 ar10 = AbstractRetrieval('10.1109/Multi-Temp.2019.8866947', view='ENTITLED', refresh=30)
 # REF view without refs
-ab11 = AbstractRetrieval('2-s2.0-0031874638', view="REF", refresh=True)
+ab11 = AbstractRetrieval('2-s2.0-0031874638', view="REF", refresh=30)
 
 
 def test_abstract():


### PR DESCRIPTION
Handle articles without references in the Scopus API like [this](https://www.scopus.com/record/display.uri?eid=2-s2.0-0002077717&origin=resultslist&sort=r-f&src=s&sid=8b6b1f0ebf8fe1eb73c8e768b3aa7195&sot=b&sdt=b&s=TITLE-ABS-KEY%28Assessing+the+temporal+stability+of+drug-using+classifications%3A+An+examination+of+Washington%2C+DC+arrestees+between+1990+and+1997%29&sl=28&sessionSearchId=8b6b1f0ebf8fe1eb73c8e768b3aa7195&relpos=0). Interestingly, the [article](https://www.sciencedirect.com/science/article/pii/S0047235200000738#aep-bibliography-id28) does have references, any thoughts @Michael-E-Rose ?