### PR TITLE
#332 AuthorRetrieval().name_variants field doc_count is now integer

### DIFF
--- a/docs/classes/AuthorRetrieval.rst
+++ b/docs/classes/AuthorRetrieval.rst
@@ -55,11 +55,11 @@ Information regarding the author's names includes:
     'J.R.'
     >>> au.name_variants
     [Variant(indexed_name='Kitchin J.', initials='J.R.', surname='Kitchin',
-     given_name='John R.', doc_count='105'),
+     given_name='John R.', doc_count=104),
      Variant(indexed_name='Kitchin J.', initials='J.', surname='Kitchin',
-     given_name='John', doc_count='13'),
+     given_name='John', doc_count=13),
      Variant(indexed_name='Kitchin J.', initials='J.R.', surname='Kitchin',
-     given_name='J. R.', doc_count='8')]
+     given_name='J. R.', doc_count=8)]
     >>> au.eid
     '9-s2.0-7004212771'
 

--- a/pybliometrics/scopus/author_retrieval.py
+++ b/pybliometrics/scopus/author_retrieval.py
@@ -173,7 +173,8 @@ class AuthorRetrieval(Retrieval):
         fields = 'indexed_name initials surname given_name doc_count'
         variant = namedtuple('Variant', fields)
         out = [variant(indexed_name=html_unescape(var['indexed-name']), surname=html_unescape(var['surname']),
-                       doc_count=var.get('@doc-count'), initials=html_unescape(var['initials']),
+                       doc_count=make_int_if_possible(var.get('@doc-count')),
+                       initials=html_unescape(var['initials']),
                        given_name=html_unescape(var.get('given-name')))
                for var in listify(self._profile.get('name-variant', []))]
         return out or None

--- a/pybliometrics/scopus/tests/test_AuthorRetrieval.py
+++ b/pybliometrics/scopus/tests/test_AuthorRetrieval.py
@@ -236,6 +236,7 @@ def test_name_variants():
         assert isinstance(received, list)
         assert len(received) > 0
         assert str(type(received[0])) == expected
+        assert isinstance(received[0].doc_count, int)
 
 
 def test_orcid():


### PR DESCRIPTION
New result with `doc_count` as int:

> [Variant(indexed_name='Kitchin J.', initials='J.R.', surname='Kitchin', given_name='John R.', doc_count=104),
>  Variant(indexed_name='Kitchin J.', initials='J.', surname='Kitchin', given_name='John', doc_count=13),
>  Variant(indexed_name='Kitchin J.', initials='J.R.', surname='Kitchin', given_name='J. R.', doc_count=8)]