### PR TITLE
#336 If AbstractRetrieval collaboration is a list then get every item

### DIFF
--- a/docs/classes/AbstractRetrieval.rst
+++ b/docs/classes/AbstractRetrieval.rst
@@ -117,16 +117,14 @@ The same structure applies for the attributes `affiliation` and `authorgroup`:
                  city='Pittsburgh', country='United States')]
 
     >>> ab.authorgroup
-    [Author(affiliation_id=60105007, dptid=None,
+    [Author(affiliation_id=60105007, collaboration_id=None, dptid=None,
             organization='Max Planck Institute for Innovation and Competition',
-            city=None, postalcode=None, addresspart=None, country='Germany',
-            collaboration=None, auid=57209617104, orcid=None,
-            indexed_name='Rose M.E.', surname='Rose', given_name='Michael E.'),
-     Author(affiliation_id=60027950, dptid=110785688,
+            city=None, postalcode=None, addresspart=None, country='Germany', auid=57209617104,
+            orcid=None, indexed_name='Rose M.E.', surname='Rose', given_name='Michael E.'),
+     Author(affiliation_id=60027950, collaboration_id=None, dptid=110785688,
             organization='Carnegie Mellon University, Department of Chemical Engineering',
-            city=None, postalcode=None, addresspart=None, country='United States',
-            collaboration=None, auid=7004212771, orcid=None,
-            indexed_name='Kitchin J.R.', surname='Kitchin', given_name='John R.')]
+            city=None, postalcode=None, addresspart=None, country='United States', auid=7004212771,
+            orcid=None, indexed_name='Kitchin J.R.', surname='Kitchin', given_name='John R.')]
 
 
 

--- a/pybliometrics/scopus/abstract_retrieval.py
+++ b/pybliometrics/scopus/abstract_retrieval.py
@@ -72,7 +72,8 @@ class AbstractRetrieval(Retrieval):
         # Check for collaboration
         keys = [k for x in items for k in list(x.keys())]
         if "collaboration" in keys:
-            collaboration = items.pop(-1)['collaboration']
+            collaboration = items[-1]['collaboration']
+            items = items[:-1]
         else:
             collaboration = {'ce:indexed-name': None}
         # Iterate through each author-affiliation combination
@@ -87,6 +88,11 @@ class AbstractRetrieval(Retrieval):
             org = _get_org(aff)
             # Author information (might relate to collaborations)
             authors = listify(item.get('author', item.get('collaboration', [])))
+            # Get collaboration (might be one dict or list of dicts)
+            try:
+                collab = collaboration.get('ce:indexed-name')
+            except AttributeError:
+                collab = [col.get('ce:indexed-name') for col in collaboration]
             for au in authors:
                 try:
                     given = au.get('ce:given-name', au['ce:initials'])
@@ -99,7 +105,7 @@ class AbstractRetrieval(Retrieval):
                            postalcode=aff.get('postal-code'),
                            addresspart=aff.get('address-part'),
                            country=aff.get('country'),
-                           collaboration=collaboration.get('ce:indexed-name'),
+                           collaboration=collab,
                            auid=int(au['@auid']),
                            orcid=au.get('@orcid'),
                            surname=au.get('ce:surname'),

--- a/pybliometrics/scopus/abstract_retrieval.py
+++ b/pybliometrics/scopus/abstract_retrieval.py
@@ -63,54 +63,39 @@ class AbstractRetrieval(Retrieval):
         # 2. A list of dicts with as in 1, one for each affiliation (incl. missing)
         # 3. A list of two dicts with one key each (author and collaboration)
         # Initialization
-        fields = 'affiliation_id dptid organization city postalcode '\
-                 'addresspart country collaboration auid orcid indexed_name '\
-                 'surname given_name'
-        auth = namedtuple('Author', fields)
+        fields = 'affiliation_id collaboration_id dptid organization city postalcode '\
+            'addresspart country auid orcid indexed_name surname given_name'
+        auth = namedtuple('Author', fields, defaults=[None for _ in fields.split()])
         items = listify(self._head.get('author-group', []))
-        index_path = ['preferred-name', 'ce:indexed-name']
-        # Check for collaboration
-        keys = [k for x in items for k in list(x.keys())]
-        if "collaboration" in keys:
-            collaboration = items[-1]['collaboration']
-            items = items[:-1]
-        else:
-            collaboration = {'ce:indexed-name': None}
-        # Iterate through each author-affiliation combination
         out = []
-        for item in items:
-            if not item:
-                continue
-            # Affiliation information
+        for item in filter(None, items):
+            # Get all possible items: affiliation, author, collaboration
             aff = item.get('affiliation', {})
+            authors = item.get('author', [])
+            collaborations = item.get('collaboration', {})
+            # Affiliation information
             aff_id = make_int_if_possible(aff.get("@afid"))
             dep_id = make_int_if_possible(aff.get("@dptid"))
             org = _get_org(aff)
-            # Author information (might relate to collaborations)
-            authors = listify(item.get('author', item.get('collaboration', [])))
-            # Get collaboration (might be one dict or list of dicts)
-            try:
-                collab = collaboration.get('ce:indexed-name')
-            except AttributeError:
-                collab = [col.get('ce:indexed-name') for col in collaboration]
-            for au in authors:
-                try:
-                    given = au.get('ce:given-name', au['ce:initials'])
-                except KeyError:  # Collaboration
-                    given = au.get('ce:text')
+            # Author information
+            for author in authors:
                 new = auth(affiliation_id=aff_id,
-                           organization=org,
-                           city=aff.get('city'),
-                           dptid=dep_id,
-                           postalcode=aff.get('postal-code'),
-                           addresspart=aff.get('address-part'),
-                           country=aff.get('country'),
-                           collaboration=collab,
-                           auid=int(au['@auid']),
-                           orcid=au.get('@orcid'),
-                           surname=au.get('ce:surname'),
-                           given_name=given,
-                           indexed_name=chained_get(au, index_path))
+                            organization=org,
+                            city=aff.get('city'),
+                            dptid=dep_id,
+                            postalcode=aff.get('postal-code'),
+                            addresspart=aff.get('address-part'),
+                            country=aff.get('country'),
+                            auid=make_int_if_possible(author.get('@auid')),
+                            orcid=author.get('@orcid'),
+                            surname=author.get('ce:surname'),
+                            given_name=author.get('ce:given-name', author['ce:initials']),
+                            indexed_name=chained_get(author, ['preferred-name', 'ce:indexed-name']))
+                out.append(new)
+            # Collaboration information
+            for collaboration in filter(None, listify(collaborations)):
+                new = auth(collaboration_id=collaboration.get('@collaboration-instance-id'),
+                        indexed_name=collaboration.get('ce:indexed-name'))
                 out.append(new)
         return out or None
 

--- a/pybliometrics/scopus/abstract_retrieval.py
+++ b/pybliometrics/scopus/abstract_retrieval.py
@@ -49,9 +49,9 @@ class AbstractRetrieval(Retrieval):
 
     @property
     def authorgroup(self) -> Optional[List[NamedTuple]]:
-        """A list of namedtuples representing the article's authors organized
-        by affiliation, in the form `(affiliation_id, dptid, organization,
-        city, postalcode, addresspart, country, collaboration, auid, orcid,
+        """A list of namedtuples representing the article's authors and collaborations
+        organized by affiliation, in the form `(affiliation_id, collaboration_id, dptid,
+        organization, city, postalcode, addresspart, country, auid, orcid,
         indexed_name, surname, given_name)`.
         If `given_name` is not present, fall back to initials.
         Note: Affiliation information might be missing or mal-assigned even

--- a/pybliometrics/scopus/tests/test_AbstractRetrieval.py
+++ b/pybliometrics/scopus/tests/test_AbstractRetrieval.py
@@ -28,6 +28,8 @@ ab9 = AbstractRetrieval("2-s2.0-85097473741", view="FULL", refresh=30)
 ar10 = AbstractRetrieval('10.1109/Multi-Temp.2019.8866947', view='ENTITLED', refresh=30)
 # REF view without refs
 ab11 = AbstractRetrieval('2-s2.0-0031874638', view="REF", refresh=30)
+# FULL view with list of collaborations
+ab12 = AbstractRetrieval('2-s2.0-85044008512', view='FULL', refresh=30)
 
 
 def test_abstract():
@@ -67,22 +69,25 @@ def test_authkeywords():
 
 
 def test_authorgroup():
-    fields = 'affiliation_id dptid organization city postalcode addresspart '\
-             'country collaboration auid orcid indexed_name surname given_name'
-    auth = namedtuple('Author', fields)
+    fields = 'affiliation_id collaboration_id dptid organization city postalcode '\
+        'addresspart country auid orcid indexed_name surname given_name'
+    auth = namedtuple('Author', fields, defaults=[None for _ in fields.split()])
+    # Test FULL document w.o. collaboration
     expected = [auth(affiliation_id=60104842, dptid=None,
         organization='Department of Chemical Engineering, Carnegie Mellon University',
         city='Pittsburgh', postalcode='15213', addresspart='5000 Forbes Avenue',
-        country='United States', collaboration=None, auid=7004212771, orcid=None,
-        indexed_name='Kitchin J.R.', surname='Kitchin', given_name='John R.')]
+        country='United States', auid=7004212771, orcid=None, indexed_name='Kitchin J.R.',
+        surname='Kitchin', given_name='John R.')]
     assert ab1.authorgroup == expected
-    assert ab8.authorgroup is None
-    expected = auth(affiliation_id=None, dptid=None, organization=None,
-        city=None, postalcode=None, addresspart=None, country=None,
-        collaboration='J-PARC-HI Collaboration', auid=7403019450, orcid=None,
-        indexed_name='Ahn J.K.', surname='Ahn', given_name='J.K.')
+    # Test FULL document w. 1 collaboration
+    expected = auth(auid=7403019450, indexed_name='Ahn J.K.', surname='Ahn', given_name='J.K.')
     assert ab9.authorgroup[0] == expected
-
+    # Test FULL document w. list of collaborations
+    expected = auth(collaboration_id='S0920379618302370-8f4b482a50491834a3f938b012344bfd',
+                indexed_name='JET Contributors')
+    assert ab12.authorgroup[-1] == expected
+    # Test REF view
+    assert ab8.authorgroup is None
 
 
 def test_authors():


### PR DESCRIPTION
The collaboration data takes two forms:
A list of dictionaries
```py
{'collaboration': [{...}, {...}]}
```
or one dictionary
``` py
{'collaboration': {...}}
```

This PR includes the required changes to handle both cases.