### PR TITLE
#338 Unescape unicode

### DIFF
--- a/pybliometrics/scopus/scopus_search.py
+++ b/pybliometrics/scopus/scopus_search.py
@@ -233,9 +233,8 @@ def _join(item, key, sep=";", unescape=False):
     the elements are not None.
     """
     try:
-        if unescape:
-            return html_unescape(sep.join([d[key] or "" for d in item["affiliation"]]))
-        return sep.join([d[key] or "" for d in item["affiliation"]])
+        string = sep.join([d[key] or "" for d in item["affiliation"]])
+        return html_unescape(string) if unescape else string
     except (KeyError, TypeError):
         return None
 

--- a/pybliometrics/scopus/scopus_search.py
+++ b/pybliometrics/scopus/scopus_search.py
@@ -123,7 +123,7 @@ class ScopusSearch(Search):
                  integrity_fields: Union[List[str], Tuple[str, ...]] = None,
                  integrity_action: str = "raise",
                  subscriber: bool = True,
-                 unescape: bool = False,
+                 unescape: bool = True,
                  **kwds: str
                  ) -> None:
         """Interaction with the Scopus Search API.

--- a/pybliometrics/scopus/scopus_search.py
+++ b/pybliometrics/scopus/scopus_search.py
@@ -1,11 +1,10 @@
 from collections import namedtuple
 from typing import List, NamedTuple, Optional, Tuple, Union
-from html import unescape as html_unescape
 
 from pybliometrics.scopus.superclasses import Search
 from pybliometrics.scopus.utils import check_integrity, chained_get,\
     check_parameter_value, check_field_consistency, deduplicate,\
-    get_freetoread, listify, make_search_summary, VIEWS
+    get_freetoread, html_unescape, listify, make_search_summary, VIEWS
 
 
 class ScopusSearch(Search):

--- a/pybliometrics/scopus/tests/test_ScopusSearch.py
+++ b/pybliometrics/scopus/tests/test_ScopusSearch.py
@@ -18,6 +18,7 @@ doc = namedtuple('Document', order)
 # Set to refresh=False because of citation count
 s_au = ScopusSearch('AU-ID(24320488600)', refresh=30)
 s_j = ScopusSearch('SOURCE-ID(22900) AND PUBYEAR IS 2010', refresh=30)
+s_d = ScopusSearch("DOI(10.1038/s41556-022-01034-3)", unescape=True, refresh=30)
 q_empty = 'SOURCE-ID(19700188323) AND PUBYEAR IS 1900'
 s_empty = ScopusSearch(q_empty, refresh=30)
 
@@ -96,3 +97,7 @@ def test_results_journal():
 
 def test_results_empty():
     assert s_empty.results is None
+
+
+def test_results_unescape():
+    assert len(s_d.results[0].afid.split(";")) == len(s_d.results[0].affilname.split(";"))

--- a/pybliometrics/scopus/tests/test_ScopusSearch.py
+++ b/pybliometrics/scopus/tests/test_ScopusSearch.py
@@ -18,7 +18,7 @@ doc = namedtuple('Document', order)
 # Set to refresh=False because of citation count
 s_au = ScopusSearch('AU-ID(24320488600)', refresh=30)
 s_j = ScopusSearch('SOURCE-ID(22900) AND PUBYEAR IS 2010', refresh=30)
-s_d = ScopusSearch("DOI(10.1038/s41556-022-01034-3)", unescape=True, refresh=30)
+s_d = ScopusSearch("DOI(10.1038/s41556-022-01034-3)", unescape=False, refresh=30)
 q_empty = 'SOURCE-ID(19700188323) AND PUBYEAR IS 1900'
 s_empty = ScopusSearch(q_empty, refresh=30)
 
@@ -100,4 +100,5 @@ def test_results_empty():
 
 
 def test_results_unescape():
-    assert len(s_d.results[0].afid.split(";")) == len(s_d.results[0].affilname.split(";"))
+    assert s_d.results[0].afid.count(";") == 14
+    assert '&amp;' in s_d.results[0].affilname

--- a/pybliometrics/scopus/tests/test_ScopusSearch.py
+++ b/pybliometrics/scopus/tests/test_ScopusSearch.py
@@ -16,11 +16,11 @@ order = 'eid doi pii pubmed_id title subtype subtypeDescription creator '\
 doc = namedtuple('Document', order)
 
 # Set to refresh=False because of citation count
-s_au = ScopusSearch('AU-ID(24320488600)', refresh=30)
-s_j = ScopusSearch('SOURCE-ID(22900) AND PUBYEAR IS 2010', refresh=30)
+s_au = ScopusSearch('AU-ID(24320488600)', unescape=False, refresh=30)
+s_j = ScopusSearch('SOURCE-ID(22900) AND PUBYEAR IS 2010', unescape=True, refresh=30)
 s_d = ScopusSearch("DOI(10.1038/s41556-022-01034-3)", unescape=False, refresh=30)
 q_empty = 'SOURCE-ID(19700188323) AND PUBYEAR IS 1900'
-s_empty = ScopusSearch(q_empty, refresh=30)
+s_empty = ScopusSearch(q_empty, unescape=False, refresh=30)
 
 
 def test_get_eids_author():
@@ -74,8 +74,8 @@ def test_results_journal():
         'protection and the income growth rate are fragile determinants of '\
         'R&D investment. © 2009 Elsevier B.V. All rights reserved.'
     keywords = 'Extreme-Bounds-Analysis (EBA) | Patent rights protection | '\
-        'R&amp;D investment | Technology transfer'
-    title = 'Determinants of R&amp;D investment: The Extreme-Bounds-'\
+        'R&D investment | Technology transfer'
+    title = 'Determinants of R&D investment: The Extreme-Bounds-'\
             'Analysis approach applied to 26 OECD countries'
     expected = doc(eid='2-s2.0-74249121335', doi='10.1016/j.respol.2009.11.010',
         pii='S0048733309002145', pubmed_id=None, title=title, subtype='ar',

--- a/pybliometrics/scopus/utils/parse_content.py
+++ b/pybliometrics/scopus/utils/parse_content.py
@@ -94,8 +94,7 @@ def get_link(dct, idx, path=['coredata', 'link']):
 
 
 def html_unescape(s: str):
-    """Convert all named and numeric character references in the
-    string s to the corresponding Unicode characters."""
+    """Convert s to Unicode characters if possible."""
     return unescape(s) if s else None
 
 

--- a/pybliometrics/scopus/utils/parse_content.py
+++ b/pybliometrics/scopus/utils/parse_content.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 from functools import reduce
 from html import unescape
+from typing import Any, Dict, Optional
 from warnings import warn
 
 
@@ -91,6 +92,14 @@ def get_link(dct, idx, path=['coredata', 'link']):
         return links[idx].get('@href')
     except IndexError:
         return None
+
+
+def get_unescaped_or_raw(item: Dict[str, Any], key: str, un_escape: bool) -> Optional[str]:
+    """Retrieve a value from a dictionary and optionally unescape HTML characters."""
+    value = item.get(key)
+    if value:
+        return html_unescape(value) if un_escape else value
+    return None
 
 
 def html_unescape(s: str):

--- a/pybliometrics/scopus/utils/parse_content.py
+++ b/pybliometrics/scopus/utils/parse_content.py
@@ -94,14 +94,6 @@ def get_link(dct, idx, path=['coredata', 'link']):
         return None
 
 
-def get_unescaped_or_raw(item: Dict[str, Any], key: str, un_escape: bool) -> Optional[str]:
-    """Retrieve a value from a dictionary and optionally unescape HTML characters."""
-    value = item.get(key)
-    if value:
-        return html_unescape(value) if un_escape else value
-    return None
-
-
 def html_unescape(s: str):
     """Convert s to Unicode characters if possible."""
     return unescape(s) if s else None

--- a/pybliometrics/scopus/utils/parse_content.py
+++ b/pybliometrics/scopus/utils/parse_content.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from functools import reduce
+from html import unescape
 from warnings import warn
 
 
@@ -92,9 +93,10 @@ def get_link(dct, idx, path=['coredata', 'link']):
         return None
 
 
-def html_unescape(s:str): 
-        from html import unescape
-        return unescape(s) if s else None
+def html_unescape(s: str):
+    """Convert all named and numeric character references in the
+    string s to the corresponding Unicode characters."""
+    return unescape(s) if s else None
 
 
 def listify(element):


### PR DESCRIPTION
Unescape unicode in following fields of `results`: `affilname`, `afid`, `affiliation-city`, `affiliation-country`. Now thinking about it, should we just unescape `affilname` @Michael-E-Rose ?