### PR TITLE
#340 Use cache paths of config instead  of DEFAULT_PATHS

### DIFF
--- a/pybliometrics/scopus/utils/startup.py
+++ b/pybliometrics/scopus/utils/startup.py
@@ -63,11 +63,9 @@ def check_default_paths(config: Type[ConfigParser], config_path: Type[Path]) -> 
 
 def create_cache_folders(config: Type[ConfigParser]) -> None:
     """Auxiliary function to create cache folders."""
-    section = 'Directories'
-    for api in config.options(section):
-        path = Path(config.get(section, api))
+    for api, path in config.items('Directories'):
         for view in VIEWS[api]:
-            view_path = path/view
+            view_path = Path(path, view)
             view_path.mkdir(parents=True, exist_ok=True)
 
 

--- a/pybliometrics/scopus/utils/startup.py
+++ b/pybliometrics/scopus/utils/startup.py
@@ -88,3 +88,4 @@ def get_keys() -> List[str]:
     else:
         keys = [k.strip() for k in CONFIG.get('Authentication', 'APIKey').split(",")]
     return keys
+

--- a/pybliometrics/scopus/utils/startup.py
+++ b/pybliometrics/scopus/utils/startup.py
@@ -38,6 +38,7 @@ def init(config_dir: Optional[str] = CONFIG_FILE, keys: Optional[List[str]] = No
 
     check_sections(CONFIG)
     check_default_paths(CONFIG, config_dir)
+    create_cache_folders(CONFIG)
 
     CUSTOM_KEYS = keys
 
@@ -48,17 +49,26 @@ def check_sections(config: Type[ConfigParser]) -> None:
         if not config.has_section(section):
             raise NoSectionError(section)
 
+
 def check_default_paths(config: Type[ConfigParser], config_path: Type[Path]) -> None:
     """Auxiliary function to check if default cache paths exist.
-    If not, the paths are writen in the config"""
+    If not, the paths are writen in the config."""
     for api, path in DEFAULT_PATHS.items():
         if not config.has_option('Directories', api):
             config.set('Directories', api, str(path))
             with open(config_path, 'w', encoding='utf-8') as ouf:
                 config.write(ouf)
+
+
+def create_cache_folders(config: Type[ConfigParser]) -> None:
+    """Auxiliary function to create cache folders."""
+    section = 'Directories'
+    for api in config.options(section):
+        path = Path(config.get(section, api))
         for view in VIEWS[api]:
             view_path = path/view
             view_path.mkdir(parents=True, exist_ok=True)
+
 
 def get_config() -> Type[ConfigParser]:
     """Function to get the config parser."""
@@ -69,6 +79,7 @@ def get_config() -> Type[ConfigParser]:
                                 'https://pybliometrics.readthedocs.io/en/stable/configuration.html')
     return CONFIG
 
+
 def get_keys() -> List[str]:
     """Function to get the API keys and overwrite keys in config if needed."""
     if CUSTOM_KEYS:
@@ -76,4 +87,3 @@ def get_keys() -> List[str]:
     else:
         keys = [k.strip() for k in CONFIG.get('Authentication', 'APIKey').split(",")]
     return keys
-

--- a/pybliometrics/scopus/utils/startup.py
+++ b/pybliometrics/scopus/utils/startup.py
@@ -52,7 +52,8 @@ def check_sections(config: Type[ConfigParser]) -> None:
 
 def check_default_paths(config: Type[ConfigParser], config_path: Type[Path]) -> None:
     """Auxiliary function to check if default cache paths exist.
-    If not, the paths are writen in the config."""
+    If not, the paths are writen in the config.
+    """
     for api, path in DEFAULT_PATHS.items():
         if not config.has_option('Directories', api):
             config.set('Directories', api, str(path))


### PR DESCRIPTION
The current code was using the `DEFAULT_PATHS` for the creation of the cache folder. This confusion was mainly driven by the function `check_default_paths()` being responsible of checking the cache paths in the config file **and** creating the cache folders. The new PR uses a new function to create the folders separately (and improving readability).