### PR TITLE
Feat 346: Implementation of the Science Direct Article Metadata API

### DIFF
--- a/pybliometrics/sciencedirect/__init__.py
+++ b/pybliometrics/sciencedirect/__init__.py
@@ -1,3 +1,4 @@
 from pybliometrics.utils import *
 
 from pybliometrics.sciencedirect.article_retrieval import *
+from pybliometrics.sciencedirect.article_metadata import *

--- a/pybliometrics/sciencedirect/article_metadata.py
+++ b/pybliometrics/sciencedirect/article_metadata.py
@@ -46,12 +46,13 @@ class ArticleMetadata(Search):
             authors = ';'.join(authors_list)
             first_author = item.get('dc:creator')[0].get('$')
             link = item.get('link')[0].get('@href')
+            doi = item.get("prism:doi") or item.get("dc:identifier")[4:] if item.get("dc:identifier") else None
             new = doc(authorKeywords=item.get('authkeywords'),
                     authors=authors,
                     available_online_date=item.get('available-online-date'),
                     first_author=first_author,
                     abstract_text=item.get('dc:description'),
-                    doi=item.get('prism:doi') or item.get('dc:identifier'),
+                    doi=doi,
                     title=item.get('dc:title'),
                     eid=item.get('eid'),
                     link=link,
@@ -92,8 +93,7 @@ class ArticleMetadata(Search):
                  ) -> None:
         """Interaction with the Science Direct Article Metadata API.
 
-        :param query: A string of the query as used in the `Advanced Search <https://service.elsevier.com/app/answers/detail/a_id/11365/supporthub/scopus/#tips>`__.
-        All fields except "INDEXTERMS()" and "LIMIT-TO()" work.
+        :param query: A string of the query as used in the `Advanced Search <https://dev.elsevier.com/tecdoc_sdsearch_migration.html>`__.
         :param refresh: Whether to refresh the cached file if it exists or not.
                         If int is passed, cached file will be refreshed if the
                         number of days since last modification exceeds that value.

--- a/pybliometrics/sciencedirect/article_metadata.py
+++ b/pybliometrics/sciencedirect/article_metadata.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from typing import List, NamedTuple, Optional, Tuple, Union
 
 from pybliometrics.superclasses import Search
-from pybliometrics.utils import chained_get, check_field_consistency, check_integrity,\
+from pybliometrics.utils import check_field_consistency, chained_get, check_integrity,\
     check_parameter_value, deduplicate, make_search_summary, VIEWS
 
 

--- a/pybliometrics/sciencedirect/article_metadata.py
+++ b/pybliometrics/sciencedirect/article_metadata.py
@@ -1,0 +1,173 @@
+from collections import namedtuple
+from typing import List, NamedTuple, Optional, Tuple, Union
+
+from pybliometrics.superclasses import Search
+from pybliometrics.utils import chained_get, check_field_consistency, check_integrity,\
+    check_parameter_value, deduplicate, make_search_summary, VIEWS
+
+
+class ArticleMetadata(Search):
+    @property
+    def results(self) -> Optional[List[NamedTuple]]:
+        """A list of namedtuples in the form `(authorKeywords authors available_online_date
+        first_author abstract_text doi title eid link openArchiveArticle openaccess_status
+        openaccessArticle openaccessUserLicense pii aggregationType copyright coverDate
+        coverDisplayDate edition endingPage isbn publicationName startingPage teaser
+        api_link publicationType vor_available_online_date)`.
+
+        Field definitions correspond to the `Article Metadata Views
+        <https://dev.elsevier.com/sd_article_meta_views.html>`__ and return the
+        values as-is, except for `authors` which are joined on `";"`.
+
+        Raises
+        ------
+        ValueError
+            If the elements provided in `integrity_fields` do not match the
+            actual field names (listed above).
+
+        Notes
+        -----
+        The list of authors and the list of affiliations per author are
+        deduplicated.
+        """
+        fields = 'authorKeywords authors available_online_date first_author abstract_text ' \
+            'doi title eid link openArchiveArticle openaccess_status openaccessArticle '\
+            'openaccessUserLicense pii aggregationType copyright coverDate coverDisplayDate '\
+            'edition endingPage isbn publicationName startingPage teaser api_link publicationType '\
+            'vor_available_online_date'
+        doc = namedtuple('Document', fields)
+        check_field_consistency(self._integrity, fields)
+        # Parse elements one-by-one
+        out = []
+        for item in self._json:
+            # Get authors and create ";" separated string
+            authors_list = [author.get('$') for author in chained_get(item, ['authors', 'author'], [])]
+            authors_list = deduplicate(authors_list)
+            authors = ';'.join(authors_list)
+            first_author = item.get('dc:creator')[0].get('$')
+            link = item.get('link')[0].get('@href')
+            new = doc(authorKeywords=item.get('authkeywords'),
+                    authors=authors,
+                    available_online_date=item.get('available-online-date'),
+                    first_author=first_author,
+                    abstract_text=item.get('dc:description'),
+                    doi=item.get('prism:doi') or item.get('dc:identifier'),
+                    title=item.get('dc:title'),
+                    eid=item.get('eid'),
+                    link=link,
+                    openArchiveArticle=item.get('openArchiveArticle'),
+                    openaccess_status=item.get('openaccess'),
+                    openaccessArticle=item.get('openaccessArticle'),
+                    openaccessUserLicense=item.get('openaccessUserLicense'),
+                    pii=item.get('pii'),
+                    aggregationType=item.get('prism:aggregationType'),
+                    copyright=item.get('prism:copyright'),
+                    coverDate=item.get('prism:coverDate'),
+                    coverDisplayDate=item.get('prism:coverDisplayDate'),
+                    edition=item.get('prism:edition'),
+                    endingPage=item.get('prism:endingPage'),
+                    isbn=item.get('prism:isbn'),
+                    publicationName=item.get('prism:publicationName'),
+                    startingPage=item.get('prism:startingPage'),
+                    teaser=item.get('prism:teaser'),
+                    api_link=item.get('prism:url'),
+                    publicationType=item.get('pubType'),
+                    vor_available_online_date=item.get('vor-available-online-date'),
+                    )
+            out.append(new)
+        check_integrity(out, self._integrity, self._action)
+        return out or None
+
+
+    def __init__(self,
+                 query: str,
+                 refresh: Union[bool, int] = False,
+                 view: str = None,
+                 verbose: bool = False,
+                 download: bool = True,
+                 integrity_fields: Union[List[str], Tuple[str, ...]] = None,
+                 integrity_action: str = "raise",
+                 subscriber: bool = True,
+                 **kwds: str
+                 ) -> None:
+        """Interaction with the Science Direct Article Metadata API.
+
+        :param query: A string of the query as used in the `Advanced Search <https://service.elsevier.com/app/answers/detail/a_id/11365/supporthub/scopus/#tips>`__.
+        All fields except "INDEXTERMS()" and "LIMIT-TO()" work.
+        :param refresh: Whether to refresh the cached file if it exists or not.
+                        If int is passed, cached file will be refreshed if the
+                        number of days since last modification exceeds that value.
+        :param view: Which view to use for the query, see `the documentation <https://dev.elsevier.com/sd_article_meta_views.html>`__.
+                     Allowed values: `STANDARD`, `COMPLETE`.  If `None`, defaults to
+                     `COMPLETE` if `subscriber=True` and to `STANDARD` if
+                     `subscriber=False`.
+        :param verbose: Whether to print a download progress bar.
+        :param download: Whether to download results (if they have not been
+                         cached).
+        :param integrity_fields: A list or tuple with the names of fields whose completeness should
+                                 be checked.  `ArticleMetadata` will perform the
+                                 action specified in `integrity_action` if
+                                 elements in these fields are missing.  This
+                                 helps avoiding idiosynchratically missing
+                                 elements that should always be present
+                                 (e.g., EID or source ID).
+        :param integrity_action: What to do in case integrity of provided fields
+                                 cannot be verified.  Possible actions:
+                                 - `"raise"`: Raise an `AttributeError`
+                                 - `"warn"`: Raise a `UserWarning`
+        :param subscriber: Whether you access Science Direct with a subscription or not.
+                           For subscribers, Science Direct's cursor navigation will be
+                           used.  Sets the number of entries in each query
+                           iteration to the maximum number allowed by the
+                           corresponding view.
+        :param unescape: Convert named and numeric characters in the `results` to
+                        their corresponding Unicode characters.
+        :param kwds: Keywords passed on as query parameters.  Must contain
+                     fields and values mentioned in the `API specification <https://dev.elsevier.com/documentation/ArticleMetadataAPI.wadl>`__.
+
+        Raises
+        ------
+        ScopusQueryError
+            For non-subscribers, if the number of search results exceeds 5000.
+
+        ValueError
+            If any of the parameters `integrity_action`, `refresh` or `view`
+            is not one of the allowed values.
+
+        Notes
+        -----
+        The directory for cached results is `{path}/{view}/{fname}`,
+        where `path` is specified in your configuration file and `fname` is
+        the md5-hashed version of `query`.
+        """
+        # Check view or set to default
+        if view:
+            check_parameter_value(view, VIEWS['ArticleMetadata'], "view")
+        else:
+            view = "COMPLETE" if subscriber else "STANDARD"
+
+        allowed = ("warn", "raise")
+        check_parameter_value(integrity_action, allowed, "integrity_action")
+
+        size = 25  # for pagination
+        if view == "STANDARD" and subscriber:
+            size = 200
+
+        # Query
+        self._action = integrity_action
+        self._integrity = integrity_fields or []
+        self._refresh = refresh
+        self._query = query
+        self._view = view
+        Search.__init__(self, query=query, api="ArticleMetadata", size=size,
+                        download=download, verbose=verbose, **kwds)
+
+
+    def __str__(self):
+        """Print a summary string."""
+        return make_search_summary(self, "document", self.get_eids())
+
+
+    def get_eids(self):
+        """EIDs of retrieved documents."""
+        return [d['eid'] for d in self._json]

--- a/pybliometrics/sciencedirect/tests/test_ArticleMetadata.py
+++ b/pybliometrics/sciencedirect/tests/test_ArticleMetadata.py
@@ -6,8 +6,12 @@ from pybliometrics.sciencedirect import ArticleMetadata, init
 
 init()
 
-am_standard = ArticleMetadata('TITLE("Bayesian Network") AND YEAR(2015)', view="STANDARD", refresh=30)
-am_complete = ArticleMetadata('AFFIL("MIT") AND YEAR("2023") AND DOI(10.1016/B978-0-32-399851-2.00030-2)', view="COMPLETE", refresh=30)
+am_standard = ArticleMetadata('TITLE("Bayesian Network") AND YEAR(2015)',
+                              view="STANDARD",
+                              refresh=30)
+am_complete = ArticleMetadata('AFFIL("MIT") AND YEAR("2023") AND DOI(10.1016/B978-0-32-399851-2.00030-2)',
+                              view="COMPLETE",
+                              refresh=30)
 am_empty = ArticleMetadata('TITLE("Not a very realistic title")', view="STANDARD", refresh=30)
 
 

--- a/pybliometrics/sciencedirect/tests/test_ArticleMetadata.py
+++ b/pybliometrics/sciencedirect/tests/test_ArticleMetadata.py
@@ -115,8 +115,8 @@ def test_length():
 
 
 def test_string():
-    expected_str = 'Search \'AFFIL("MIT") AND YEAR("2023") AND DOI(10.1016/B978-0-32-399851-2.00030-2)\' yielded 1 document as of 2024-08-13:\n    3-s2.0-B9780323998512000302'
-    assert am_complete.__str__() == expected_str
+    part_of_str = 'Search \'AFFIL("MIT") AND YEAR("2023") AND DOI(10.1016/B978-0-32-399851-2.00030-2)\' yielded 1 document as of'
+    assert part_of_str in am_complete.__str__()
 
 
 def test_wrong_query():

--- a/pybliometrics/sciencedirect/tests/test_ArticleMetadata.py
+++ b/pybliometrics/sciencedirect/tests/test_ArticleMetadata.py
@@ -1,0 +1,128 @@
+"""Tests for sciencedirect.ArticleMetadata"""
+from collections import namedtuple
+
+from pybliometrics.exception import Scopus400Error
+from pybliometrics.sciencedirect import ArticleMetadata, init
+
+init()
+
+am_standard = ArticleMetadata('TITLE("Bayesian Network") AND YEAR(2015)', view="STANDARD", refresh=30)
+am_complete = ArticleMetadata('AFFIL("MIT") AND YEAR("2023") AND DOI(10.1016/B978-0-32-399851-2.00030-2)', view="COMPLETE", refresh=30)
+am_empty = ArticleMetadata('TITLE("Not a very realistic title")', view="STANDARD", refresh=30)
+
+
+def test_empty_results():
+    assert am_empty.results is None
+    assert am_empty._n == 0
+
+
+def test_all_fields():
+    fields = (
+        "authorKeywords authors available_online_date first_author abstract_text "
+        "doi title eid link openArchiveArticle openaccess_status openaccessArticle "
+        "openaccessUserLicense pii aggregationType copyright coverDate coverDisplayDate "
+        "edition endingPage isbn publicationName startingPage teaser api_link publicationType "
+        "vor_available_online_date"
+    )
+    doc = namedtuple("Document", fields)
+
+    expected_complete_doc = doc(
+        authorKeywords="Large scale learning | Few shot learning | Meta learning",
+        authors="Balaji, Yogesh",
+        available_online_date="2022-09-30",
+        first_author="Sankaranarayanan, Swami",
+        abstract_text="Meta learning techniques have been successfully used to mitigate issues such as distribution shift in neural network training. However, the proposed approaches remain complex to train and less scalable. In this chapter, we discuss some recent approaches that have successfully demonstrated the use of meta learning based techniques in a big data setting such as Imagenet and beyond.",
+        doi="10.1016/B978-0-32-399851-2.00030-2",
+        title="Meta learning in the big data regime Applications to transfer learning and few shot learning",
+        eid="3-s2.0-B9780323998512000302",
+        link="https://www.sciencedirect.com/science/article/pii/B9780323998512000302",
+        openArchiveArticle=False,
+        openaccess_status="0",
+        openaccessArticle=False,
+        openaccessUserLicense=None,
+        pii="B978-0-32-399851-2.00030-2",
+        aggregationType="EBook",
+        copyright="Copyright © 2023 Elsevier Inc. All rights reserved.",
+        coverDate="2023-12-31",
+        coverDisplayDate="2023",
+        edition=None,
+        endingPage="393",
+        isbn="9780323998512",
+        publicationName="Meta Learning With Medical Imaging and Health Informatics Applications",
+        startingPage="385",
+        teaser="Meta learning techniques have been successfully used to mitigate issues such as distribution shift in neural network training. However, the proposed approaches remain complex to train and less scalable....",
+        api_link="https://api.elsevier.com/content/article/pii/B9780323998512000302",
+        publicationType="chp",
+        vor_available_online_date="2022-09-30",
+    )
+    assert am_complete.results[0] == expected_complete_doc
+
+    expected_standard_doc = doc(
+        authorKeywords=None,
+        authors="Zhong, Lu;Haijun, Zeng",
+        available_online_date="2015-02-14",
+        first_author="Kang, Chen",
+        abstract_text=None,
+        doi="10.1016/j.proeng.2014.12.523",
+        title="Research on Probabilistic Safety Analysis Approach of Flight Control System Based on Bayesian Network",
+        eid="1-s2.0-S1877705814036376",
+        link="https://www.sciencedirect.com/science/article/pii/S1877705814036376",
+        openArchiveArticle=False,
+        openaccess_status="1",
+        openaccessArticle=True,
+        openaccessUserLicense="http://creativecommons.org/licenses/by-nc-nd/4.0/",
+        pii="S1877-7058(14)03637-6",
+        aggregationType=None,
+        copyright=None,
+        coverDate="2015-12-31",
+        coverDisplayDate="2015",
+        edition=None,
+        endingPage="184",
+        isbn=None,
+        publicationName="Procedia Engineering",
+        startingPage="180",
+        teaser="Traditional probabilistic safety analysis methods are not suitable for modern flight control system with multi-state probability. In this papera Bayesian Network based probabilistic safety model is...",
+        api_link="https://api.elsevier.com/content/article/pii/S1877705814036376",
+        publicationType="fla",
+        vor_available_online_date=None,
+    )
+    assert am_standard.results[0] == expected_standard_doc
+
+
+def test_field_consistency():
+    am_wrong_field = ArticleMetadata('TITLE("Bayesian Network") AND YEAR(2015)',
+                                 integrity_fields=["notExistingField"],
+                                 integrity_action="warn",
+                                 view="STANDARD",
+                                 refresh=30)
+    try:
+        am_wrong_field.results
+    except ValueError:
+        pass
+    except Exception as e:
+        raise AssertionError(f"Unexpected exception type: {type(e).__name__}")
+    else:
+        raise AssertionError("Expected ValueError but no exception was raised")
+
+
+def test_length():
+    assert len(am_standard.results) == am_standard._n
+    assert len(am_complete.results) == am_complete._n
+
+
+def test_string():
+    expected_str = 'Search \'AFFIL("MIT") AND YEAR("2023") AND DOI(10.1016/B978-0-32-399851-2.00030-2)\' yielded 1 document as of 2024-08-13:\n    3-s2.0-B9780323998512000302'
+    assert am_complete.__str__() == expected_str
+
+
+def test_wrong_query():
+    try:
+        ArticleMetadata(
+            'TITLE("Bayesian Network") AND YEAR(2015', view="STANDARD", refresh=30
+        )
+    except Scopus400Error:
+        pass
+    except Exception as e:
+        raise AssertionError(f"Unexpected exception type: {type(e).__name__}")
+    else:
+        raise AssertionError("Expected Scopus400Error but no exception was raised")

--- a/pybliometrics/utils/constants.py
+++ b/pybliometrics/utils/constants.py
@@ -24,6 +24,7 @@ DEFAULT_PATHS = {
     'SerialTitle': BASE_PATH_SCOPUS/'serial_title',
     'PlumXMetrics': BASE_PATH_SCOPUS/'plumx',
     'SubjectClassifications': BASE_PATH_SCOPUS/'subject_classification',
+    'ArticleMetadata': BASE_PATH_SCIENCEDIRECT/'article_metadata/',
     'ArticleRetrieval': BASE_PATH_SCIENCEDIRECT/'article_retrieval'
 }
 
@@ -53,6 +54,7 @@ URLS = {
     'SerialTitle': RETRIEVAL_BASE + 'serial/title/issn/',
     'SubjectClassifications': RETRIEVAL_BASE + 'subject/scopus',
     'PlumXMetrics': 'https://api.elsevier.com/analytics/plumx/',
+    'ArticleMetadata': RETRIEVAL_BASE + 'metadata/article/',
     'ArticleRetrieval': RETRIEVAL_BASE + 'article/'
 }
 
@@ -69,7 +71,8 @@ VIEWS = {
     "SerialSearch": ["STANDARD", "ENHANCED", "CITESCORE"],
     "SerialTitle": ["STANDARD", "ENHANCED", "CITESCORE"],
     "SubjectClassifications": [''],
-    "ArticleRetrieval": ["META", "META_ABS", "META_ABS_REF", "FULL", "ENTITLED"]
+    "ArticleRetrieval": ["META", "META_ABS", "META_ABS_REF", "FULL", "ENTITLED"],
+    "ArticleMetadata": ["STANDARD", "COMPLETE"]
 }
 
 # Throttling limits (in queries per second) // 0 = no limit
@@ -85,8 +88,10 @@ RATELIMITS = {
     'SerialTitle': 6,
     'PlumXMetrics': 6,
     'SubjectClassifications': 0,
+    'ArticleMetadata': 6,
     'ArticleRetrieval': 10
 }
 
 # Other API restrictions
 SEARCH_MAX_ENTRIES = 5_000
+


### PR DESCRIPTION
Implementation of the [Science Direct Article Metadata API](https://dev.elsevier.com/documentation/ArticleMetadataAPI.wadl).