### PR TITLE
Feat 348: ScienceDirect Search API V2

### DIFF
--- a/pybliometrics/__init__.py
+++ b/pybliometrics/__init__.py
@@ -1,9 +1,4 @@
-import sys
-
-if sys.version_info >= (3, 8):
-    from importlib.metadata import version
-else:
-    from importlib_metadata import version
+from importlib.metadata import version
 
 __version__ = version("pybliometrics")
 

--- a/pybliometrics/sciencedirect/__init__.py
+++ b/pybliometrics/sciencedirect/__init__.py
@@ -2,3 +2,4 @@ from pybliometrics.utils import *
 
 from pybliometrics.sciencedirect.article_retrieval import *
 from pybliometrics.sciencedirect.article_metadata import *
+from pybliometrics.sciencedirect.sciencedirect_search import *

--- a/pybliometrics/sciencedirect/article_metadata.py
+++ b/pybliometrics/sciencedirect/article_metadata.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from typing import List, NamedTuple, Optional, Tuple, Union
 
 from pybliometrics.superclasses import Search
-from pybliometrics.utils import chained_get, check_field_consistency, check_integrity,\
+from pybliometrics.utils import check_field_consistency, chained_get, check_integrity,\
     check_parameter_value, deduplicate, make_search_summary, VIEWS
 
 

--- a/pybliometrics/sciencedirect/article_metadata.py
+++ b/pybliometrics/sciencedirect/article_metadata.py
@@ -46,12 +46,13 @@ class ArticleMetadata(Search):
             authors = ';'.join(authors_list)
             first_author = item.get('dc:creator')[0].get('$')
             link = item.get('link')[0].get('@href')
+            doi = item.get("prism:doi") or item.get("dc:identifier")[4:] if item.get("dc:identifier") else None
             new = doc(authorKeywords=item.get('authkeywords'),
                     authors=authors,
                     available_online_date=item.get('available-online-date'),
                     first_author=first_author,
                     abstract_text=item.get('dc:description'),
-                    doi=item.get('prism:doi') or item.get('dc:identifier'),
+                    doi=doi,
                     title=item.get('dc:title'),
                     eid=item.get('eid'),
                     link=link,

--- a/pybliometrics/sciencedirect/article_metadata.py
+++ b/pybliometrics/sciencedirect/article_metadata.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from typing import List, NamedTuple, Optional, Tuple, Union
 
 from pybliometrics.superclasses import Search
-from pybliometrics.utils import check_field_consistency, chained_get, check_integrity,\
+from pybliometrics.utils import chained_get, check_field_consistency, check_integrity,\
     check_parameter_value, deduplicate, make_search_summary, VIEWS
 
 
@@ -46,13 +46,12 @@ class ArticleMetadata(Search):
             authors = ';'.join(authors_list)
             first_author = item.get('dc:creator')[0].get('$')
             link = item.get('link')[0].get('@href')
-            doi = item.get("prism:doi") or item.get("dc:identifier")[4:] if item.get("dc:identifier") else None
             new = doc(authorKeywords=item.get('authkeywords'),
                     authors=authors,
                     available_online_date=item.get('available-online-date'),
                     first_author=first_author,
                     abstract_text=item.get('dc:description'),
-                    doi=doi,
+                    doi=item.get('prism:doi') or item.get('dc:identifier'),
                     title=item.get('dc:title'),
                     eid=item.get('eid'),
                     link=link,
@@ -93,7 +92,8 @@ class ArticleMetadata(Search):
                  ) -> None:
         """Interaction with the Science Direct Article Metadata API.
 
-        :param query: A string of the query as used in the `Advanced Search <https://dev.elsevier.com/tecdoc_sdsearch_migration.html>`__.
+        :param query: A string of the query as used in the `Advanced Search <https://service.elsevier.com/app/answers/detail/a_id/11365/supporthub/scopus/#tips>`__.
+        All fields except "INDEXTERMS()" and "LIMIT-TO()" work.
         :param refresh: Whether to refresh the cached file if it exists or not.
                         If int is passed, cached file will be refreshed if the
                         number of days since last modification exceeds that value.

--- a/pybliometrics/sciencedirect/article_metadata.py
+++ b/pybliometrics/sciencedirect/article_metadata.py
@@ -93,8 +93,7 @@ class ArticleMetadata(Search):
                  ) -> None:
         """Interaction with the Science Direct Article Metadata API.
 
-        :param query: A string of the query as used in the `Advanced Search <https://service.elsevier.com/app/answers/detail/a_id/11365/supporthub/scopus/#tips>`__.
-        All fields except "INDEXTERMS()" and "LIMIT-TO()" work.
+        :param query: A string of the query as used in the `Advanced Search <https://dev.elsevier.com/tecdoc_sdsearch_migration.html>`__.
         :param refresh: Whether to refresh the cached file if it exists or not.
                         If int is passed, cached file will be refreshed if the
                         number of days since last modification exceeds that value.

--- a/pybliometrics/sciencedirect/sciencedirect_search.py
+++ b/pybliometrics/sciencedirect/sciencedirect_search.py
@@ -47,10 +47,11 @@ class ScienceDirectSearch(Search):
                     links['api_link'] = link.get('@href')
                 elif link.get('@ref') == 'scidir':
                     links['scidir'] = link.get('@href')
-
+            # Get doi
+            doi = item.get("prism:doi") or item.get("dc:identifier")[4:] if item.get("dc:identifier") else None
             new = doc(authors=authors,
                 first_author=item.get('dc:creator'),
-                doi=item.get("prism:doi") or item.get("dc:identifier"),
+                doi=doi,
                 title=item.get("dc:title"),
                 link=links["scidir"],
                 load_date=item.get("load-date"),
@@ -149,8 +150,8 @@ class ScienceDirectSearch(Search):
 
     def __str__(self):
         """Print a summary string."""
-        return make_search_summary(self, "document", self.get_eids())
+        return make_search_summary(self, "document", self.get_dois())
 
-    def get_eids(self):
-        """EIDs of retrieved documents."""
-        return [d['eid'] for d in self._json]
+    def get_dois(self):
+        """DOIs of retrieved documents."""
+        return [d.get("prism:doi") or d.get("dc:identifier")[4:] if d.get("dc:identifier") else None for d in self._json]

--- a/pybliometrics/sciencedirect/sciencedirect_search.py
+++ b/pybliometrics/sciencedirect/sciencedirect_search.py
@@ -1,0 +1,156 @@
+from collections import namedtuple
+from typing import List, NamedTuple, Optional, Tuple, Union
+
+from pybliometrics.superclasses import Search
+from pybliometrics.utils import check_field_consistency, chained_get, check_integrity,\
+    check_parameter_value, deduplicate, make_search_summary, VIEWS
+
+
+class ScienceDirectSearch(Search):
+    @property
+    def results(self) -> Optional[List[NamedTuple]]:
+        """A list of namedtuples in the form `(authors first_author doi title link
+        load_date openaccess_status pii coverDate endingPage publicationName startingPage
+        api_link volume)`.
+
+        Field definitions correspond to the `ScienceDirect Search Views
+        <https://dev.elsevier.com/sd_search_views.htmll>`__ and return the
+        values as-is, except for `authors` which are joined on `";"`.
+
+        Raises
+        ------
+        ValueError
+            If the elements provided in `integrity_fields` do not match the
+            actual field names (listed above).
+
+        Notes
+        -----
+        The list of authors and the list of affiliations per author are
+        deduplicated.
+        """
+        fields = 'authors first_author doi title link load_date openaccess_status pii '\
+            'coverDate endingPage publicationName startingPage api_link volume'
+        doc = namedtuple('Document', fields)
+        check_field_consistency(self._integrity, fields)
+        # Parse elements one-by-one
+        out = []
+        for item in self._json:
+            # Get authors and create ";" separated string
+            authors_list = [author.get('$') for author in chained_get(item, ['authors', 'author'], [])]
+            authors_list = deduplicate(authors_list)
+            authors = ';'.join(authors_list)
+            # Get links
+            links_found = item.get('link')
+            links = {'api_link': None, 'scidir': None}
+            for link in links_found:
+                if link.get('@ref') == 'self':
+                    links['api_link'] = link.get('@href')
+                elif link.get('@ref') == 'scidir':
+                    links['scidir'] = link.get('@href')
+
+            new = doc(authors=authors,
+                first_author=item.get('dc:creator'),
+                doi=item.get("prism:doi") or item.get("dc:identifier"),
+                title=item.get("dc:title"),
+                link=links["scidir"],
+                load_date=item.get("load-date"),
+                openaccess_status=item.get("openaccess"),
+                pii=item.get("pii"),
+                coverDate=item.get("prism:coverDate"),
+                endingPage=item.get("prism:endingPage"),
+                publicationName=item.get("prism:publicationName"),
+                startingPage=item.get("prism:startingPage"),
+                api_link=links["api_link"] or item.get("prism:url"),
+                volume=item.get("prism:volume"))
+            out.append(new)
+        check_integrity(out, self._integrity, self._action)
+        return out or None
+
+    def __init__(self,
+                 query: str,
+                 refresh: Union[bool, int] = False,
+                 view: str = None,
+                 verbose: bool = False,
+                 download: bool = True,
+                 integrity_fields: Union[List[str], Tuple[str, ...]] = None,
+                 integrity_action: str = "raise",
+                 subscriber: bool = True,
+                 **kwds: str
+                 ) -> None:
+        """Interaction with the ScienceDirect Search API. This represents a search against the
+        ScienceDirect cluster, which contains serial/nonserial full-text articles. Note that this API
+        replicates the search experience on `Science Direct <www.sciencedirect.com>`__.
+
+        :param query: A string of the query as used in the `Science Direct Search <https://dev.elsevier.com/tecdoc_sdsearch_migration.html>`__. Note that
+        this library uses the GET interface.
+        :param refresh: Whether to refresh the cached file if it exists or not.
+                        If int is passed, cached file will be refreshed if the
+                        number of days since last modification exceeds that value.
+        :param view: Which view to use for the query, see `the documentation <https://dev.elsevier.com/sd_search_views.html>`__.
+                     Allowed values: `STANDARD`.
+        :param verbose: Whether to print a download progress bar.
+        :param download: Whether to download results (if they have not been
+                         cached).
+        :param integrity_fields: A list or tuple with the names of fields whose completeness should
+                                 be checked.  `ArticleMetadata` will perform the
+                                 action specified in `integrity_action` if
+                                 elements in these fields are missing.  This
+                                 helps avoiding idiosynchratically missing
+                                 elements that should always be present
+                                 (e.g., EID or source ID).
+        :param integrity_action: What to do in case integrity of provided fields
+                                 cannot be verified.  Possible actions:
+                                 - `"raise"`: Raise an `AttributeError`
+                                 - `"warn"`: Raise a `UserWarning`
+        :param subscriber: Whether you access Science Direct with a subscription or not.
+                           For subscribers, Science Direct's cursor navigation will be
+                           used.  Sets the number of entries in each query
+                           iteration to the maximum number allowed by the
+                           corresponding view.
+        :param kwds: Keywords passed on as query parameters.  Must contain
+                     fields and values mentioned in the `API specification <https://dev.elsevier.com/documentation/ArticleMetadataAPI.wadl>`__.
+
+        Raises
+        ------
+        ScopusQueryError
+            For non-subscribers, if the number of search results exceeds 5000.
+
+        ValueError
+            If any of the parameters `integrity_action`, `refresh` or `view`
+            is not one of the allowed values.
+
+        Notes
+        -----
+        The directory for cached results is `{path}/{view}/{fname}`,
+        where `path` is specified in your configuration file and `fname` is
+        the md5-hashed version of `query`.
+        """
+        # Check view or set to default
+        if view:
+            check_parameter_value(view, VIEWS['ScienceDirectSearch'], "view")
+        else:
+            view = "STANDARD"
+
+        allowed = ("warn", "raise")
+        check_parameter_value(integrity_action, allowed, "integrity_action")
+
+        size = 25  # for pagination
+        if view == "STANDARD" and subscriber:
+            size = 200
+
+        # Query
+        self._action = integrity_action
+        self._integrity = integrity_fields or []
+        self._refresh = refresh
+        self._query = query
+        self._view = view
+        Search.__init__(self, query=query, api="ScienceDirectSearch", size=size,
+                        download=download, verbose=verbose, **kwds)
+
+    def __str__(self):
+        """Print a summary string."""
+        return make_search_summary(self, "document", self.get_eids())
+
+    def get_eids(self):
+        """EIDs of retrieved documents."""
+        return [d['eid'] for d in self._json]

--- a/pybliometrics/sciencedirect/sciencedirect_search.py
+++ b/pybliometrics/sciencedirect/sciencedirect_search.py
@@ -70,10 +70,10 @@ class ScienceDirectSearch(Search):
     def __init__(self,
                  query: str,
                  refresh: Union[bool, int] = False,
-                 view: str = None,
+                 view: Optional[str] = None,
                  verbose: bool = False,
                  download: bool = True,
-                 integrity_fields: Union[List[str], Tuple[str, ...]] = None,
+                 integrity_fields: Optional[Union[List[str], Tuple[str, ...]]] = None,
                  integrity_action: str = "raise",
                  subscriber: bool = True,
                  **kwds: str
@@ -82,8 +82,7 @@ class ScienceDirectSearch(Search):
         ScienceDirect cluster, which contains serial/nonserial full-text articles. Note that this API
         replicates the search experience on `Science Direct <www.sciencedirect.com>`__.
 
-        :param query: A string of the query as used in the `Science Direct Search <https://dev.elsevier.com/tecdoc_sdsearch_migration.html>`__. Note that
-        this library uses the GET interface.
+        :param query: A string of the query as used in the `Science Direct Search <https://dev.elsevier.com/tecdoc_sdsearch_migration.html>`__.
         :param refresh: Whether to refresh the cached file if it exists or not.
                         If int is passed, cached file will be refreshed if the
                         number of days since last modification exceeds that value.
@@ -98,7 +97,7 @@ class ScienceDirectSearch(Search):
                                  elements in these fields are missing.  This
                                  helps avoiding idiosynchratically missing
                                  elements that should always be present
-                                 (e.g., EID or source ID).
+                                 (e.g., doi or authors).
         :param integrity_action: What to do in case integrity of provided fields
                                  cannot be verified.  Possible actions:
                                  - `"raise"`: Raise an `AttributeError`
@@ -125,6 +124,9 @@ class ScienceDirectSearch(Search):
         The directory for cached results is `{path}/{view}/{fname}`,
         where `path` is specified in your configuration file and `fname` is
         the md5-hashed version of `query`.
+
+        The ScienceDirect Search API V2 has two available interfaces: `PUT` and `GET`. This library uses the
+        `GET` interface.
         """
         # Check view or set to default
         if view:

--- a/pybliometrics/sciencedirect/tests/test_ScienceDirectSearch.py
+++ b/pybliometrics/sciencedirect/tests/test_ScienceDirectSearch.py
@@ -1,0 +1,78 @@
+"""Tests for sciencedirect.ScienceDirectSearch"""
+from collections import namedtuple
+
+from pybliometrics.exception import Scopus400Error
+from pybliometrics.sciencedirect import ScienceDirectSearch, init
+
+init()
+
+sds_standard = ScienceDirectSearch('Title("LLMs") AND DATE(2012)', view="STANDARD", refresh=30)
+sds_empty = ScienceDirectSearch('TITLE("Not a very realistic title")', view="STANDARD", refresh=30)
+
+
+def test_empty_results():
+    assert sds_empty.results is None
+    assert sds_empty._n == 0
+
+
+def test_all_fields():
+    fields = 'authors first_author doi title link load_date openaccess_status pii '\
+        'coverDate endingPage publicationName startingPage api_link volume'
+    doc = namedtuple("Document", fields)
+
+    expected_standard_doc = doc(
+        authors="Constantinos Patsakis;Fran Casino;Nikolaos Lykousas",
+        first_author="Constantinos Patsakis",
+        doi="10.1016/j.eswa.2024.124912",
+        title="Assessing LLMs in malicious code deobfuscation of real-world malware campaigns",
+        link="https://www.sciencedirect.com/science/article/pii/S0957417424017792?dgcid=api_sd_search-api-endpoint",
+        load_date="2024-07-31T00:00:00.000Z",
+        openaccess_status=True,
+        pii="S0957417424017792",
+        coverDate="2024-12-05",
+        endingPage=None,
+        publicationName="Expert Systems with Applications",
+        startingPage="124912",
+        api_link="https://api.elsevier.com/content/article/pii/S0957417424017792",
+        volume="256",
+    )
+    assert sds_standard.results[0] == expected_standard_doc
+
+
+def test_field_consistency():
+    am_wrong_field = ScienceDirectSearch('Title("LLMs") AND DATE(2012)',
+                                 integrity_fields=["notExistingField"],
+                                 integrity_action="warn",
+                                 view="STANDARD",
+                                 refresh=30)
+    try:
+        am_wrong_field.results
+    except ValueError:
+        pass
+    except Exception as e:
+        raise AssertionError(f"Unexpected exception type: {type(e).__name__}")
+    else:
+        raise AssertionError("Expected ValueError but no exception was raised")
+
+
+def test_length():
+    assert len(sds_standard.results) == sds_standard._n
+    assert len(sds_standard.results) == sds_standard._n
+
+
+def test_string():
+    str_start = 'Search \'Title("LLMs") AND DATE(2012)\' yielded 25 documents as of'
+    assert sds_standard.__str__().startswith(str_start)
+
+
+def test_wrong_query():
+    try:
+        ScienceDirectSearch(
+            'Th(s querY - has M&ny ( Errors', view="STANDARD", refresh=30
+        )
+    except Scopus400Error:
+        pass
+    except Exception as e:
+        raise AssertionError(f"Unexpected exception type: {type(e).__name__}")
+    else:
+        raise AssertionError("Expected Scopus400Error but no exception was raised")

--- a/pybliometrics/sciencedirect/tests/test_ScienceDirectSearch.py
+++ b/pybliometrics/sciencedirect/tests/test_ScienceDirectSearch.py
@@ -6,7 +6,7 @@ from pybliometrics.sciencedirect import ScienceDirectSearch, init
 
 init()
 
-sds_standard = ScienceDirectSearch('Title("LLMs") AND DATE(2012)', view="STANDARD", refresh=30)
+sds_standard = ScienceDirectSearch('TITLE("Assessing LLMs in malicious code deobfuscation of real-world malware campaigns") AND DATE(2012)', view="STANDARD", refresh=30)
 sds_empty = ScienceDirectSearch('TITLE("Not a very realistic title")', view="STANDARD", refresh=30)
 
 
@@ -40,7 +40,7 @@ def test_all_fields():
 
 
 def test_field_consistency():
-    am_wrong_field = ScienceDirectSearch('Title("LLMs") AND DATE(2012)',
+    am_wrong_field = ScienceDirectSearch('TITLE("Assessing LLMs in malicious code deobfuscation of real-world malware campaigns") AND DATE(2012)',
                                  integrity_fields=["notExistingField"],
                                  integrity_action="warn",
                                  view="STANDARD",
@@ -61,7 +61,8 @@ def test_length():
 
 
 def test_string():
-    str_start = 'Search \'Title("LLMs") AND DATE(2012)\' yielded 25 documents as of'
+    str_start = ('Search \'TITLE("Assessing LLMs in malicious code deobfuscation of '
+    'real-world malware campaigns") AND DATE(2012)\' yielded 1 document as of')
     assert sds_standard.__str__().startswith(str_start)
 
 

--- a/pybliometrics/scopus/affiliation_search.py
+++ b/pybliometrics/scopus/affiliation_search.py
@@ -2,8 +2,10 @@ from collections import namedtuple
 from typing import List, NamedTuple, Optional, Tuple, Union
 
 from pybliometrics.superclasses import Search
-from pybliometrics.utils import check_integrity, check_parameter_value,\
-    check_field_consistency, make_int_if_possible, make_search_summary
+from pybliometrics.utils import check_integrity, check_parameter_value, \
+    check_field_consistency, html_unescape, make_int_if_possible, \
+    make_search_summary
+
 
 
 class AffiliationSearch(Search):
@@ -30,12 +32,13 @@ class AffiliationSearch(Search):
         # Parse elements one-by-one
         out = []
         for item in self._json:
-            name = item.get('affiliation-name')
-            variants = [d.get('$', "") for d in item.get('name-variant', [])
+            name = item['affiliation-name']
+            variants = [html_unescape(d.get('$', ""))
+                        for d in item.get('name-variant', [])
                         if d.get('$', "") != name]
             parent = make_int_if_possible(item.get('parent-affiliation-id')) or None
             new = aff(eid=item.get('eid'), variant=";".join(variants),
-                      documents=int(item['document-count']), name=name,
+                      documents=int(item['document-count']), name=html_unescape(name),
                       city=item.get('city'), country=item.get('country'),
                       parent=parent)
             out.append(new)

--- a/pybliometrics/utils/constants.py
+++ b/pybliometrics/utils/constants.py
@@ -25,7 +25,8 @@ DEFAULT_PATHS = {
     'PlumXMetrics': BASE_PATH_SCOPUS/'plumx',
     'SubjectClassifications': BASE_PATH_SCOPUS/'subject_classification',
     'ArticleMetadata': BASE_PATH_SCIENCEDIRECT/'article_metadata/',
-    'ArticleRetrieval': BASE_PATH_SCIENCEDIRECT/'article_retrieval'
+    'ArticleRetrieval': BASE_PATH_SCIENCEDIRECT/'article_retrieval',
+    'ScienceDirectSearch': BASE_PATH_SCIENCEDIRECT/'science_direct_search'
 }
 
 # Configuration file location
@@ -55,7 +56,8 @@ URLS = {
     'SubjectClassifications': RETRIEVAL_BASE + 'subject/scopus',
     'PlumXMetrics': 'https://api.elsevier.com/analytics/plumx/',
     'ArticleMetadata': RETRIEVAL_BASE + 'metadata/article/',
-    'ArticleRetrieval': RETRIEVAL_BASE + 'article/'
+    'ArticleRetrieval': RETRIEVAL_BASE + 'article/',
+    'ScienceDirectSearch': SEARCH_BASE + 'sciencedirect/'
 }
 
 # Valid views for all classes
@@ -72,7 +74,8 @@ VIEWS = {
     "SerialTitle": ["STANDARD", "ENHANCED", "CITESCORE"],
     "SubjectClassifications": [''],
     "ArticleRetrieval": ["META", "META_ABS", "META_ABS_REF", "FULL", "ENTITLED"],
-    "ArticleMetadata": ["STANDARD", "COMPLETE"]
+    "ArticleMetadata": ["STANDARD", "COMPLETE"],
+    "ScienceDirectSearch": ["STANDARD"]
 }
 
 # Throttling limits (in queries per second) // 0 = no limit
@@ -89,7 +92,8 @@ RATELIMITS = {
     'PlumXMetrics': 6,
     'SubjectClassifications': 0,
     'ArticleMetadata': 6,
-    'ArticleRetrieval': 10
+    'ArticleRetrieval': 10,
+    'ScienceDirectSearch': 2
 }
 
 # Other API restrictions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.2", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=69.1", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -39,9 +39,6 @@ Homepage = "https://github.com/pybliometrics-dev/pybliometrics"
 "Bug Tracker" = "https://github.com/pybliometrics-dev/pybliometrics/issues"
 "Documentation (stable)" = "https://pybliometrics.readthedocs.io/en/stable/"
 "Documentation (latest)" = "https://pybliometrics.readthedocs.io/en/latest/"
-
-[tool.distutils.bdist_wheel]
-universal = 1
 
 [tool.setuptools]
 include-package-data = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,11 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Documentation :: Sphinx"


### PR DESCRIPTION
Implementation of the [Search API V2](https://dev.elsevier.com/documentation/ScienceDirectSearchAPI.wadl). Views can be found [here](https://dev.elsevier.com/sd_search_views.html).