### PR TITLE
Fix `_get_all_refs()` in case only 1 reference returned

### DIFF
--- a/pybliometrics/superclasses/base.py
+++ b/pybliometrics/superclasses/base.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 
 from pybliometrics.exception import ScopusQueryError
 from pybliometrics.utils import get_content, parse_content, SEARCH_MAX_ENTRIES
-
+from pybliometrics.utils import listify
 
 class Base:
     def __init__(self,
@@ -195,7 +195,7 @@ def _get_all_refs(url: str, params: dict, verbose: bool, resp: dict, *args, **kw
         res = resp.json()
         res = parse_content.chained_get(res, path_reference)
         # Append
-        data['abstracts-retrieval-response']['references']['reference'].extend(res)
+        data['abstracts-retrieval-response']['references']['reference'].extend(listify(res))
         if verbose:
             print(f'Extracted:\n\tFrom: {kwds["startref"]}\n\tTo:{len(parse_content.chained_get(data, ["abstracts-retrieval-response", "references", "reference"]))}')
 


### PR DESCRIPTION
When querying a REF view of an item via Scopus, normally it returns a list of bibliography like
 `{"abstracts-retrieval-response": {"references": {"reference": [...] ...`
However, if there is only one entry in the bibliography, the returned content becomes 
`{"abstracts-retrieval-response": {"references": {"reference": {...} ...`. 

The bug is only triggered when handling publications with 1, 41, 81, etc., entries in their references. To illustrate, 
```python
from pybliometrics.scopus import AbstractRetrieval
doi = "10.1109/TRO.2018.2872402"  # 81 references
ab = AbstractRetrieval(doi, view='REF', refresh=True)
print(len(ab.references))
print(ab.refcount)
```

A fix is to `listify()` the value indexed by `"reference"` key.