### PR TITLE
Article retrieval

### DIFF
--- a/pybliometrics/sciencedirect/article_retrieval.py
+++ b/pybliometrics/sciencedirect/article_retrieval.py
@@ -34,7 +34,7 @@ class ArticleRetrieval(Retrieval):
         out = []
         auth = namedtuple('Author', 'surname given_name')
         for author in chained_get(self._json, ['coredata', 'dc:creator']):
-            surname, given_name = author['$'].split(',')
+            surname, given_name = author['$'].split(', ')
             new = auth(surname=surname, given_name=given_name)
             out.append(new)
         return out or None
@@ -240,10 +240,11 @@ class ArticleRetrieval(Retrieval):
             else:
                 authors = "(No author found)"
             # All other information
-            s += f'{authors}: "{self.title}", {self.publicationName}, {self.volume}'
+            s += f'{authors}: "{self.title}", {self.publicationName}'
+            s += f', {self.volume}' if self.volume else ''
             s += ', '
             s += parse_pages(self)
             s += f'({self.coverDate[:4]}).'
             if self.doi:
-                s += f' https://doi.org/{self.doi}.\n'
+                s += f' https://doi.org/{self.doi}.'
         return s

--- a/pybliometrics/sciencedirect/article_retrieval.py
+++ b/pybliometrics/sciencedirect/article_retrieval.py
@@ -189,15 +189,24 @@ class ArticleRetrieval(Retrieval):
         return make_int_if_possible(vol)
 
     def __init__(self,
-                 identifier: Union[int, str] = None,
+                 identifier: Union[int, str],
                  refresh: Union[bool, int] = False,
                  view: str = 'META',
-                 id_type: str = None,
+                 id_type: Optional[str] = None,
                  **kwds: str
                  ):
         """Interaction with the Article Retrieval API.
         
-        :param identifier: The indentifier of an article."""
+        :param identifier: The indentifier of an article.
+        :param refresh: Whether to refresh the cached file if it exists or not.
+                        If int is passed, cached file will be refreshed if the
+                        number of days since last modification exceeds that value.
+        :param view: The view of the file that should be downloaded. Allowed values:
+                        'META', 'META_ABS', 'META_ABS_REF', 'FULL', 'ENTITLED'. Default is 'META'.
+        :param id_type: The type of used ID. Allowed values: `None`, 'eid', 'pii',
+                        'scopus_id', 'pubmed_id', 'doi' and 'pui'.  If the value is `None`,
+                        pybliometrics tries to infer the ID type itself.
+        """
         identifier = str(identifier)
         check_parameter_value(view, VIEWS['ArticleRetrieval'], "view")
         if id_type is None:

--- a/pybliometrics/sciencedirect/article_retrieval.py
+++ b/pybliometrics/sciencedirect/article_retrieval.py
@@ -204,7 +204,7 @@ class ArticleRetrieval(Retrieval):
         :param view: The view of the file that should be downloaded. Allowed values:
                         'META', 'META_ABS', 'META_ABS_REF', 'FULL', 'ENTITLED'. Default is 'META'.
         :param id_type: The type of used ID. Allowed values: `None`, 'eid', 'pii',
-                        'scopus_id', 'pubmed_id', 'doi' and 'pui'.  If the value is `None`,
+                        'scopus_id', 'pubmed_id' and 'doi'.  If the value is `None`,
                         pybliometrics tries to infer the ID type itself.
         """
         identifier = str(identifier)
@@ -212,7 +212,7 @@ class ArticleRetrieval(Retrieval):
         if id_type is None:
             id_type = detect_id_type(identifier)
         else:
-            allowed_id_types = ('eid', 'pii', 'scopus_id', 'pubmed_id', 'doi', 'pui')
+            allowed_id_types = ('eid', 'pii', 'scopus_id', 'pubmed_id', 'doi')
             check_parameter_value(id_type, allowed_id_types, "id_type")
 
         self._view = view

--- a/pybliometrics/sciencedirect/tests/test_ArticleRetrieval.py
+++ b/pybliometrics/sciencedirect/tests/test_ArticleRetrieval.py
@@ -6,7 +6,7 @@ from pybliometrics.sciencedirect import ArticleRetrieval, init
 init()
 
 ar_full = ArticleRetrieval('S2949948823000112', view='FULL', refresh=30)
-ar_meta = ArticleRetrieval("10.1016/j.procs.2018.05.069", view='META', refresh=30)
+ar_meta = ArticleRetrieval("10.1016/j.procs.2018.05.069", id_type='doi', view='META', refresh=30)
 ar_meta_abs = ArticleRetrieval("S0304387823001736", view='META_ABS', refresh=30)
 ar_meta_abs_ref = ArticleRetrieval("S2352226722000630", view='META_ABS_REF', refresh=30)
 ar_entitled = ArticleRetrieval("S2213305418300365", view='ENTITLED', refresh=30)
@@ -31,22 +31,22 @@ def test_aggregationType():
 
 def test_authors():
     auth = namedtuple('Author', 'surname given_name')
-    authors_full = [auth(surname='Soori', given_name=' Mohsen'),
-                          auth(surname='Arezoo', given_name=' Behrooz'),
-                          auth(surname='Dastres', given_name=' Roza')]
-    authors_meta = [auth(surname='Indolia', given_name=' Sakshi'),
-                    auth(surname='Goswami', given_name=' Anil Kumar'),
-                    auth(surname='Mishra', given_name=' S.P.'),
-                    auth(surname='Asopa', given_name=' Pooja')]
-    authors_meta_abs = [auth(surname='Carreira', given_name=' Igor'),
-                        auth(surname='Costa', given_name=' Francisco'),
-                        auth(surname='Pessoa', given_name=' João Paulo')]
-    authors_meta_abs_ref = [auth(surname='Kudrass', given_name=' H.R.'),
-                            auth(surname='Hanebuth', given_name=' T.J.J.'),
-                            auth(surname='Zander', given_name=' A.M.'),
-                            auth(surname='Linstädter', given_name=' J.'),
-                            auth(surname='Akther', given_name=' S.H.'),
-                            auth(surname='Shohrab', given_name=' U.M.')]
+    authors_full = [auth(surname='Soori', given_name='Mohsen'),
+                          auth(surname='Arezoo', given_name='Behrooz'),
+                          auth(surname='Dastres', given_name='Roza')]
+    authors_meta = [auth(surname='Indolia', given_name='Sakshi'),
+                    auth(surname='Goswami', given_name='Anil Kumar'),
+                    auth(surname='Mishra', given_name='S.P.'),
+                    auth(surname='Asopa', given_name='Pooja')]
+    authors_meta_abs = [auth(surname='Carreira', given_name='Igor'),
+                        auth(surname='Costa', given_name='Francisco'),
+                        auth(surname='Pessoa', given_name='João Paulo')]
+    authors_meta_abs_ref = [auth(surname='Kudrass', given_name='H.R.'),
+                            auth(surname='Hanebuth', given_name='T.J.J.'),
+                            auth(surname='Zander', given_name='A.M.'),
+                            auth(surname='Linstädter', given_name='J.'),
+                            auth(surname='Akther', given_name='S.H.'),
+                            auth(surname='Shohrab', given_name='U.M.')]
     assert ar_full.authors == authors_full
     assert ar_meta.authors == authors_meta
     assert ar_meta_abs.authors == authors_meta_abs
@@ -241,3 +241,8 @@ def test_volume():
     assert ar_meta.volume == 132
     assert ar_meta_abs.volume == 167
     assert ar_meta_abs_ref.volume == 32
+
+
+def test__str__():
+    expected  = 'Mohsen Soori, Behrooz Arezoo and Roza Dastres: "Artificial neural networks in supply chain management, a review", Journal of Economy and Technology, 1, pp. 179-196(2023). https://doi.org/10.1016/j.ject.2023.11.002.'
+    assert str(ar_full) == expected

--- a/pybliometrics/utils/constants.py
+++ b/pybliometrics/utils/constants.py
@@ -64,7 +64,7 @@ VIEWS = {
     "SerialSearch": ["STANDARD", "ENHANCED", "CITESCORE"],
     "SerialTitle": ["STANDARD", "ENHANCED", "CITESCORE"],
     "SubjectClassifications": [''],
-    "ArticleRetrieval": ["BASE", "META", "META_ABS", "META_ABS_REF", "FULL", "ENTITLED"],
+    "ArticleRetrieval": ["META", "META_ABS", "META_ABS_REF", "FULL", "ENTITLED"],
     "ArticleMetadata": ["STANDARD", "COMPLETE"],
     "ScienceDirectSearch": ["STANDARD"]
 }


### PR DESCRIPTION
The following things were improved:
- Remove invalid `BASE` view and `pui` id_type
- Complete constructor docstring
- Parse authors correctly without leading whitespaces
- Test __str__() function and use of argument `id_type`