### PR TITLE
#387 Retrieve actual results size

### DIFF
--- a/pybliometrics/sciencedirect/article_metadata.py
+++ b/pybliometrics/sciencedirect/article_metadata.py
@@ -150,9 +150,9 @@ class ArticleMetadata(Search):
         allowed = ("warn", "raise")
         check_parameter_value(integrity_action, allowed, "integrity_action")
 
-        size = 25  # for pagination
+        count = 25  # for pagination
         if view == "STANDARD" and subscriber:
-            size = 200
+            count = 200
 
         # Query
         self._action = integrity_action
@@ -160,7 +160,7 @@ class ArticleMetadata(Search):
         self._refresh = refresh
         self._query = query
         self._view = view
-        Search.__init__(self, query=query, size=size, download=download, verbose=verbose, **kwds)
+        Search.__init__(self, query=query, size=count, download=download, verbose=verbose, **kwds)
 
     def __str__(self):
         """Print a summary string."""

--- a/pybliometrics/sciencedirect/article_metadata.py
+++ b/pybliometrics/sciencedirect/article_metadata.py
@@ -150,17 +150,13 @@ class ArticleMetadata(Search):
         allowed = ("warn", "raise")
         check_parameter_value(integrity_action, allowed, "integrity_action")
 
-        count = 25  # for pagination
-        if view == "STANDARD" and subscriber:
-            count = 200
-
         # Query
         self._action = integrity_action
         self._integrity = integrity_fields or []
         self._refresh = refresh
         self._query = query
         self._view = view
-        Search.__init__(self, query=query, count=count, download=download, verbose=verbose, **kwds)
+        Search.__init__(self, query=query, download=download, verbose=verbose, **kwds)
 
     def __str__(self):
         """Print a summary string."""

--- a/pybliometrics/sciencedirect/article_metadata.py
+++ b/pybliometrics/sciencedirect/article_metadata.py
@@ -160,7 +160,7 @@ class ArticleMetadata(Search):
         self._refresh = refresh
         self._query = query
         self._view = view
-        Search.__init__(self, query=query, size=count, download=download, verbose=verbose, **kwds)
+        Search.__init__(self, query=query, count=count, download=download, verbose=verbose, **kwds)
 
     def __str__(self):
         """Print a summary string."""

--- a/pybliometrics/sciencedirect/sciencedirect_search.py
+++ b/pybliometrics/sciencedirect/sciencedirect_search.py
@@ -140,9 +140,9 @@ class ScienceDirectSearch(Search):
         allowed = ("warn", "raise")
         check_parameter_value(integrity_action, allowed, "integrity_action")
 
-        size = 25  # for pagination
+        count = 25  # for pagination
         if view == "STANDARD" and subscriber:
-            size = 200
+            count = 200
 
         # Query
         self._action = integrity_action
@@ -150,7 +150,7 @@ class ScienceDirectSearch(Search):
         self._refresh = refresh
         self._query = query
         self._view = view
-        Search.__init__(self, query=query, size=size, download=download, verbose=verbose, **kwds)
+        Search.__init__(self, query=query, count=count, download=download, verbose=verbose, **kwds)
 
     def __str__(self):
         """Print a summary string."""

--- a/pybliometrics/sciencedirect/sciencedirect_search.py
+++ b/pybliometrics/sciencedirect/sciencedirect_search.py
@@ -140,17 +140,13 @@ class ScienceDirectSearch(Search):
         allowed = ("warn", "raise")
         check_parameter_value(integrity_action, allowed, "integrity_action")
 
-        count = 25  # for pagination
-        if view == "STANDARD" and subscriber:
-            count = 200
-
         # Query
         self._action = integrity_action
         self._integrity = integrity_fields or []
         self._refresh = refresh
         self._query = query
         self._view = view
-        Search.__init__(self, query=query, count=count, download=download, verbose=verbose, **kwds)
+        Search.__init__(self, query=query, download=download, verbose=verbose, **kwds)
 
     def __str__(self):
         """Print a summary string."""

--- a/pybliometrics/scopus/scopus_search.py
+++ b/pybliometrics/scopus/scopus_search.py
@@ -200,9 +200,6 @@ class ScopusSearch(Search):
                 view = "COMPLETE"
             else:
                 view = "STANDARD"
-        count = 25  # for pagination
-        if view == "STANDARD" and subscriber:
-            count = 200
         if "cursor" in kwds:
             subscriber = kwds["cursor"]
             kwds.pop("cursor")
@@ -213,7 +210,7 @@ class ScopusSearch(Search):
         self._refresh = refresh
         self._query = query
         self._view = view
-        Search.__init__(self, query=query, count=count,
+        Search.__init__(self, query=query,
                         cursor=subscriber, download=download,
                         verbose=verbose, **kwds)
         self.unescape = unescape

--- a/pybliometrics/scopus/scopus_search.py
+++ b/pybliometrics/scopus/scopus_search.py
@@ -200,9 +200,9 @@ class ScopusSearch(Search):
                 view = "COMPLETE"
             else:
                 view = "STANDARD"
-        size = 25  # for pagination
+        count = 25  # for pagination
         if view == "STANDARD" and subscriber:
-            size = 200
+            count = 200
         if "cursor" in kwds:
             subscriber = kwds["cursor"]
             kwds.pop("cursor")
@@ -213,7 +213,7 @@ class ScopusSearch(Search):
         self._refresh = refresh
         self._query = query
         self._view = view
-        Search.__init__(self, query=query, size=size,
+        Search.__init__(self, query=query, count=count,
                         cursor=subscriber, download=download,
                         verbose=verbose, **kwds)
         self.unescape = unescape

--- a/pybliometrics/superclasses/base.py
+++ b/pybliometrics/superclasses/base.py
@@ -80,7 +80,7 @@ class Base:
                 n = int(res['search-results'].get('opensearch:totalResults', 0))
                 self._n = n
                 # Get actual results size
-                params['size'] = int(res['search-results'].get('opensearch:itemsPerPage', 25))
+                params['count'] = int(res['search-results'].get('opensearch:itemsPerPage', 25))
                 # Results size check
                 cursor_exists = "cursor" in params
                 if not cursor_exists and n > SEARCH_MAX_ENTRIES:
@@ -100,14 +100,14 @@ class Base:
                     # Download the remaining information in chunks
                     if verbose:
                         print(f'Downloading results for query "{params["query"]}":')
-                    n_chunks = ceil(n/params['size'])
+                    n_chunks = ceil(n/params['count'])
                     for i in tqdm(range(1, n_chunks), disable=not verbose,
                                   initial=1, total=n_chunks):
                         if cursor_exists:
                             cursor = res['search-results']['cursor']['@next']
                             params.update({'cursor': cursor})
                         else:
-                            start += params["size"]
+                            start += params["count"]
                             params.update({'start': start})
                         resp = get_content(url, api, params, **kwds)
                         res = resp.json()

--- a/pybliometrics/superclasses/base.py
+++ b/pybliometrics/superclasses/base.py
@@ -79,6 +79,8 @@ class Base:
                 res = resp.json()
                 n = int(res['search-results'].get('opensearch:totalResults', 0))
                 self._n = n
+                # Get actual results size
+                params['size'] = int(res['search-results'].get('opensearch:itemsPerPage', 25))
                 # Results size check
                 cursor_exists = "cursor" in params
                 if not cursor_exists and n > SEARCH_MAX_ENTRIES:

--- a/pybliometrics/superclasses/base.py
+++ b/pybliometrics/superclasses/base.py
@@ -77,10 +77,8 @@ class Base:
             elif search_request:
                 # Get number of results
                 res = resp.json()
-                n = int(res['search-results'].get('opensearch:totalResults', 0))
+                n = int(res['search-results'].get('opensearch:totalResults', 0) or 0)
                 self._n = n
-                # Get actual results size
-                params['count'] = int(res['search-results'].get('opensearch:itemsPerPage', 25))
                 # Results size check
                 cursor_exists = "cursor" in params
                 if not cursor_exists and n > SEARCH_MAX_ENTRIES:

--- a/pybliometrics/superclasses/search.py
+++ b/pybliometrics/superclasses/search.py
@@ -5,13 +5,12 @@ from pathlib import Path
 from typing import Union
 
 from pybliometrics.superclasses import Base
-from pybliometrics.utils import get_config, URLS
+from pybliometrics.utils import get_config, COUNTS, URLS
 
 
 class Search(Base):
     def __init__(self,
                  query: Union[str, dict],
-                 count: int = 200,
                  cursor: bool = False,
                  download: bool = True,
                  verbose: bool = False,
@@ -20,9 +19,6 @@ class Search(Base):
         """Class intended as superclass to perform a search query.
 
         :param query : A string of the query.
-        :param count: The number of entries to be displayed at once.  A smaller
-                     number means more queries with each query having
-                     fewer results.
         :param cursor: Whether to use the cursor in order to iterate over all
                       search results without limit on the number of the results.
                       In contrast to `start` parameter, the `cursor` parameter
@@ -40,6 +36,7 @@ class Search(Base):
         """
         api = self.__class__.__name__
         # Construct query parameters
+        count = COUNTS[api][self._view]
         params = {'count': count, 'view': self._view, **kwds}
         if isinstance(query, dict):
             params.update(query)

--- a/pybliometrics/superclasses/search.py
+++ b/pybliometrics/superclasses/search.py
@@ -11,7 +11,7 @@ from pybliometrics.utils import get_config, URLS
 class Search(Base):
     def __init__(self,
                  query: Union[str, dict],
-                 size: int = 200,
+                 count: int = 200,
                  cursor: bool = False,
                  download: bool = True,
                  verbose: bool = False,
@@ -20,7 +20,7 @@ class Search(Base):
         """Class intended as superclass to perform a search query.
 
         :param query : A string of the query.
-        :param size: The number of entries to be displayed at once.  A smaller
+        :param count: The number of entries to be displayed at once.  A smaller
                      number means more queries with each query having
                      fewer results.
         :param cursor: Whether to use the cursor in order to iterate over all
@@ -40,7 +40,7 @@ class Search(Base):
         """
         api = self.__class__.__name__
         # Construct query parameters
-        params = {'size': size, 'view': self._view, **kwds}
+        params = {'count': count, 'view': self._view, **kwds}
         if isinstance(query, dict):
             params.update(query)
             name = "&".join(["=".join(t) for t in zip(query.keys(), query.values())])

--- a/pybliometrics/utils/constants.py
+++ b/pybliometrics/utils/constants.py
@@ -94,6 +94,18 @@ APIS_WITH_ID_TYPE = {"AbstractRetrieval",
                      "ObjectMetadata",
                      "ObjectRetrieval"}
 
+# Item per page limits for all classes
+COUNTS = {
+    "AffiliationSearch": {"STANDARD": 200},
+    "AuthorSearch": {"STANDARD": 200},
+    "ArticleMetadata": {"STANDARD": 200, "COMPLETE": 25},
+    "ScDirSubjectClassifications": {"": 200},
+    "ScienceDirectSearch": {"STANDARD": 100},
+    "ScopusSearch": {"STANDARD": 200, "COMPLETE": 25},
+    "SerialSearch": {"STANDARD": 200, "ENHANCED": 200, "CITESCORE": 200},
+    "SubjectClassifications": {"": 200}
+}
+
 # Throttling limits (in queries per second) // 0 = no limit
 RATELIMITS = {
     'AbstractRetrieval': 9,


### PR DESCRIPTION
- The `size` parameter does not work, instead we have to use `count` to set the number of items per page.
- I propose to define the max `count` in the `constants.py` file. 
- The documentation for the max `count` can be found [here](https://dev.elsevier.com/api_key_settings.html), with an exception of `ScienceDirectSearch` which only allows for the values (10, 25, 50, 100) using the `GET` method as stated [here](https://dev.elsevier.com/tecdoc_sdsearch_migration.html).