### PR TITLE
`__str__()` for NonserialTitle and ObjectRetrieval

### DIFF
--- a/pybliometrics/sciencedirect/nonserial_title.py
+++ b/pybliometrics/sciencedirect/nonserial_title.py
@@ -115,3 +115,18 @@ class NonserialTitle(Retrieval):
         # Parse json
         self._json = self._json['nonserial-metadata-response']
         self._entry = self._json['entry'][0]
+
+    def __str__(self) -> str:
+        """Return a citation string for the Nonserial Title."""
+        if self.authors:
+            authors = f"{self.authors}."
+        elif self.editors:
+            authors = f"{self.editors} (ed.)."
+        else:
+            authors = ""
+        edition = f", {self.edition}." if self.edition else "."
+        publisher = f" {self.publisher_name}." if self.publisher_name else "."
+        title = f" {self.title}"
+        isbn = self.isbn
+
+        return f"{authors}{title}{edition}{publisher} ISBN: {isbn}"

--- a/pybliometrics/sciencedirect/object_retrieval.py
+++ b/pybliometrics/sciencedirect/object_retrieval.py
@@ -43,6 +43,8 @@ class ObjectRetrieval(Retrieval):
             identifier = self._get_eid(identifier)
         file_identifier = f'{identifier}-{filename}'
 
+        self._identifier = identifier
+        self._filename = filename
         self._view = ''
         self._refresh = refresh
 
@@ -52,3 +54,9 @@ class ObjectRetrieval(Retrieval):
         """Get the EID of a document."""
         am = ArticleRetrieval(identifier, field='eid')
         return am.eid
+
+    def __str__(self) -> str:
+        """Return a string with the filename, document and object size in KB."""
+        size_kb = f"{len(self._object) / 1024:.1f}" if self._object else "0.0"
+        return (f"Object {self._filename} from document with EID {self._identifier}"
+                f" has size of {size_kb} KB.")

--- a/pybliometrics/sciencedirect/tests/test_NonserialTitle.py
+++ b/pybliometrics/sciencedirect/tests/test_NonserialTitle.py
@@ -79,6 +79,14 @@ def test_self_link():
     assert nst_2.self_link == "https://api.elsevier.com/content/nonserial/title/isbn/9780128203101"
     assert nst_3.self_link == "https://api.elsevier.com/content/nonserial/title/isbn/9780128217771"
 
+def test_str():
+    expected_1 = "Ian Newton. The Migration Ecology of Birds, Second Edition. Academic Press. ISBN: 9780128237519"
+    expected_2 = "Elias Barriga and Ivana Pajic-Lijakovic (ed.). Viscoelasticity and  Collective Cell Migration. Academic Press. ISBN: 9780128203101"
+    expected_3 = "Fatos Xhafa, Mohamed A. Tawhid, Pardeep Kumar and Yugal Kumar (ed.). Machine Learning, Big Data, and IoT for Medical Informatics. Academic Press. ISBN: 9780128217771"
+    assert str(nst_1) == expected_1
+    assert str(nst_2) == expected_2
+    assert str(nst_3) == expected_3
+
 
 def test_title():
     assert nst_1.title == "The Migration Ecology of Birds"

--- a/pybliometrics/sciencedirect/tests/test_ObjectRetrieval.py
+++ b/pybliometrics/sciencedirect/tests/test_ObjectRetrieval.py
@@ -30,3 +30,10 @@ def test_object():
     assert isinstance(or_2.object, BytesIO)
     assert or_2.object.getvalue()[150:200] == obj_2_150_200
     assert ET.parse(or_2.object).getroot().tag == '{http://www.w3.org/2000/svg}svg'
+
+def test_str():
+    """Tests the string representation of the ObjectRetrieval object."""
+    expected_1 = "Object gr10.jpg from document with EID 1-s2.0-S156984322300331X has size of 34.7 KB."
+    assert str(or_1) == expected_1
+    expected_2 = "Object si92.svg from document with EID 1-s2.0-S0736584520302969 has size of 10.0 KB."
+    assert str(or_2) == expected_2


### PR DESCRIPTION
An example of all the strings created for the ScienceDirect classes:

ArticleMetadata:
> Search 'AFFIL("MIT") AND YEAR("2023") AND DOI(10.1016/B978-0-32-399851-2.00030-2)' yielded 1 document as of 2025-06-04:
>     3-s2.0-B9780323998512000302 
> 
> 
ArticleRetrieval:
> Mohsen Soori, Behrooz Arezoo and Roza Dastres: "Artificial neural networks in supply chain management, a review", Journal of Economy and Technology, 1, pp. 179-196(2023). https://doi.org/10.1016/j.ject.2023.11.002. 
> 
> 
SerialTitle:
> 'Gene', journal published by 'Elsevier B.V.', is active in Genetics
> Metrics as of 2025-05-18:
>     SJR:  year value
>           2023 0.725
>     SNIP: year value
>           2023 0.765
>     ISSN: 0378-1119, E-ISSN: 1879-0038, Scopus ID: 15636 
> 
> 
NonserialTitle:
> Ian Newton. The Migration Ecology of Birds, Second Edition. Academic Press. ISBN: 9780128237519 
> 
> 
ObjectMetadata:
> Document with doi 10.1016/j.neunet.2024.106632 contains 355 objects. 
> 
> 
ObjectRetrieval:
> Object gr10.jpg from document with EID 1-s2.0-S156984322300331X has size of 34.7 KB. 
> 
> 
SubjectClassifications:
> Search '{'description': 'Chemistry', 'field': 'code,description,detail,abbrev'}' yielded 16 subject areas as of 2025-06-04:
>     18
>     399
>     400
>     405
>     416
>     191
>     9
>     37
>     62
>     417
>     137
>     175
>     184
>     116
>     101
>     150