### PR TITLE
#403 Implementation of `AuthorMetrics`

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -80,6 +80,7 @@ SciVal
 .. toctree::
     :maxdepth: 1
     
+    reference/scival/AuthorMetrics.rst
     reference/scival/PublicationLookup.rst
 
 

--- a/docs/reference/scival/AuthorMetrics.rst
+++ b/docs/reference/scival/AuthorMetrics.rst
@@ -72,18 +72,17 @@ Each metric property returns a list of `MetricData` namedtuples with the structu
 .. note::
    **Unified Data Structure**: AuthorMetrics uses a unified `MetricData` structure with `entity_id` and `entity_name` fields. For authors, these fields contain the author ID and author name respectively. This structure is compatible with `InstitutionMetrics` and other SciVal metric classes, enabling consistent data analysis across different entity types.
 
-**Getting All Metrics at Once**
+**Concatenating Metrics**
 
-You can retrieve all available metrics in a single list using the `all_metrics` property:
+Metrics can be concatenated and converted into a pandas DataFrame for easier analysis. 
 
 .. code-block:: python
 
-    >>> all_data = author_metrics.all_metrics
-    >>> len(all_data)
-    29
-    >>> # Convert to pandas DataFrame for analysis
     >>> import pandas as pd
-    >>> df = pd.DataFrame(all_data)
+    >>> collab_data = []
+    >>> collab_data.extend(author_metrics.Collaboration)
+    >>> collab_data.extend(author_metrics.CollaborationImpact)
+    >>> df = pd.DataFrame(collab_data)
     >>> df.head()
 
 
@@ -125,56 +124,89 @@ You can retrieve all available metrics in a single list using the `all_metrics` 
         <th>0</th>
         <td>6602819806</td>
         <td>Algül, Hana</td>
-        <td>Academic-corporate collaboration</td>
-        <td>AcademicCorporateCollaboration</td>
+        <td>Institutional collaboration</td>
+        <td>Collaboration</td>
         <td>all</td>
-        <td>12.000000</td>
-        <td>22.64151</td>
-        <td>NaN</td>
+        <td>6.000000</td>
+        <td>11.32</td>
+        <td>None</td>
         </tr>
         <tr>
         <th>1</th>
         <td>6602819806</td>
         <td>Algül, Hana</td>
-        <td>No academic-corporate collaboration</td>
-        <td>AcademicCorporateCollaboration</td>
+        <td>International collaboration</td>
+        <td>Collaboration</td>
         <td>all</td>
-        <td>41.000000</td>
-        <td>77.35849</td>
-        <td>NaN</td>
+        <td>26.000000</td>
+        <td>49.06</td>
+        <td>None</td>
         </tr>
         <tr>
         <th>2</th>
         <td>6602819806</td>
         <td>Algül, Hana</td>
-        <td>Academic-corporate collaboration</td>
-        <td>AcademicCorporateCollaborationImpact</td>
+        <td>National collaboration</td>
+        <td>Collaboration</td>
         <td>all</td>
-        <td>43.166668</td>
-        <td>NaN</td>
-        <td>NaN</td>
+        <td>21.000000</td>
+        <td>39.62</td>
+        <td>None</td>
         </tr>
         <tr>
         <th>3</th>
         <td>6602819806</td>
         <td>Algül, Hana</td>
-        <td>No academic-corporate collaboration</td>
-        <td>AcademicCorporateCollaborationImpact</td>
+        <td>Single authorship</td>
+        <td>Collaboration</td>
         <td>all</td>
-        <td>14.682927</td>
-        <td>NaN</td>
-        <td>NaN</td>
+        <td>0.000000</td>
+        <td>0.00</td>
+        <td>None</td>
         </tr>
         <tr>
         <th>4</th>
         <td>6602819806</td>
         <td>Algül, Hana</td>
         <td>Institutional collaboration</td>
-        <td>Collaboration</td>
+        <td>CollaborationImpact</td>
         <td>all</td>
-        <td>6.000000</td>
-        <td>11.32000</td>
+        <td>3.500000</td>
         <td>NaN</td>
+        <td>None</td>
+        </tr>
+        <tr>
+        <th>5</th>
+        <td>6602819806</td>
+        <td>Algül, Hana</td>
+        <td>International collaboration</td>
+        <td>CollaborationImpact</td>
+        <td>all</td>
+        <td>28.461538</td>
+        <td>NaN</td>
+        <td>None</td>
+        </tr>
+        <tr>
+        <th>6</th>
+        <td>6602819806</td>
+        <td>Algül, Hana</td>
+        <td>National collaboration</td>
+        <td>CollaborationImpact</td>
+        <td>all</td>
+        <td>17.095238</td>
+        <td>NaN</td>
+        <td>None</td>
+        </tr>
+        <tr>
+        <th>7</th>
+        <td>6602819806</td>
+        <td>Algül, Hana</td>
+        <td>Single authorship</td>
+        <td>CollaborationImpact</td>
+        <td>all</td>
+        <td>0.000000</td>
+        <td>NaN</td>
+        <td>None</td>
         </tr>
     </tbody>
     </table>
@@ -192,8 +224,9 @@ You can analyze multiple authors simultaneously. Furthermore, you can specify wh
     AuthorMetrics for 2 author(s):
     - Wolff, Klaus Dietrich (ID: 7201667143)
     - Vogel-Heuser, Birgit (ID: 6603480302)
-    >>> df = pd.DataFrame(multi_authors.all_metrics)
-    >>> df.tail()
+    >>> # Create a DataFrame from the Collaboration metrics
+    >>> df_multi = pd.DataFrame(multi_authors.Collaboration)
+    >>> df_multi.head()
 
 
 .. raw:: html
@@ -215,6 +248,7 @@ You can analyze multiple authors simultaneously. Furthermore, you can specify wh
             font-size: 12px;
         }
     </style>
+    <div>
     <table border="1" class="dataframe">
     <thead>
         <tr style="text-align: right;">
@@ -231,62 +265,63 @@ You can analyze multiple authors simultaneously. Furthermore, you can specify wh
     </thead>
     <tbody>
         <tr>
-        <th>275</th>
-        <td>6603480302</td>
-        <td>Vogel-Heuser, Birgit</td>
-        <td>OutputsInTopCitationPercentiles</td>
-        <td>OutputsInTopCitationPercentiles</td>
+        <th>0</th>
+        <td>7201667143</td>
+        <td>Wolff, Klaus Dietrich</td>
+        <td>Institutional collaboration</td>
+        <td>Collaboration</td>
         <td>2024</td>
-        <td>5.0</td>
-        <td>13.157895</td>
-        <td>25.0</td>
+        <td>3</td>
+        <td>30.000002</td>
+        <td>None</td>
         </tr>
         <tr>
-        <th>276</th>
-        <td>6603480302</td>
-        <td>Vogel-Heuser, Birgit</td>
-        <td>OutputsInTopCitationPercentiles</td>
-        <td>OutputsInTopCitationPercentiles</td>
+        <th>1</th>
+        <td>7201667143</td>
+        <td>Wolff, Klaus Dietrich</td>
+        <td>Institutional collaboration</td>
+        <td>Collaboration</td>
         <td>2020</td>
-        <td>5.0</td>
-        <td>10.000000</td>
-        <td>25.0</td>
+        <td>3</td>
+        <td>16.666668</td>
+        <td>None</td>
         </tr>
         <tr>
-        <th>277</th>
-        <td>6603480302</td>
-        <td>Vogel-Heuser, Birgit</td>
-        <td>OutputsInTopCitationPercentiles</td>
-        <td>OutputsInTopCitationPercentiles</td>
+        <th>2</th>
+        <td>7201667143</td>
+        <td>Wolff, Klaus Dietrich</td>
+        <td>Institutional collaboration</td>
+        <td>Collaboration</td>
         <td>2021</td>
-        <td>14.0</td>
-        <td>27.450981</td>
-        <td>25.0</td>
+        <td>2</td>
+        <td>25.000000</td>
+        <td>None</td>
         </tr>
         <tr>
-        <th>278</th>
-        <td>6603480302</td>
-        <td>Vogel-Heuser, Birgit</td>
-        <td>OutputsInTopCitationPercentiles</td>
-        <td>OutputsInTopCitationPercentiles</td>
+        <th>3</th>
+        <td>7201667143</td>
+        <td>Wolff, Klaus Dietrich</td>
+        <td>Institutional collaboration</td>
+        <td>Collaboration</td>
         <td>2022</td>
-        <td>8.0</td>
-        <td>24.242424</td>
-        <td>25.0</td>
+        <td>0</td>
+        <td>0.000000</td>
+        <td>None</td>
         </tr>
         <tr>
-        <th>279</th>
-        <td>6603480302</td>
-        <td>Vogel-Heuser, Birgit</td>
-        <td>OutputsInTopCitationPercentiles</td>
-        <td>OutputsInTopCitationPercentiles</td>
+        <th>4</th>
+        <td>7201667143</td>
+        <td>Wolff, Klaus Dietrich</td>
+        <td>Institutional collaboration</td>
+        <td>Collaboration</td>
         <td>2023</td>
-        <td>1.0</td>
-        <td>2.173913</td>
-        <td>25.0</td>
+        <td>4</td>
+        <td>30.769232</td>
+        <td>None</td>
         </tr>
     </tbody>
     </table>
+    </div>
     </div>
 
 

--- a/docs/reference/scival/AuthorMetrics.rst
+++ b/docs/reference/scival/AuthorMetrics.rst
@@ -1,0 +1,309 @@
+pybliometrics.scival.AuthorMetrics
+==================================
+
+`AuthorMetrics()` implements the `SciVal Author Metrics API <https://dev.elsevier.com/documentation/SciValAuthorAPI.wadl>`_.
+
+It accepts one or more Scopus Author IDs as the main argument and retrieves various performance metrics for the specified authors.
+
+.. currentmodule:: pybliometrics.scival
+.. contents:: Table of Contents
+    :local:
+
+Documentation
+-------------
+
+.. autoclass:: AuthorMetrics
+    :members:
+    :inherited-members:
+
+Examples
+--------
+
+You initialize the class with one or more Scopus Author IDs. The argument can be a single ID, a list of IDs, or a comma-separated string of IDs.
+
+.. code-block:: python
+
+    >>> import pybliometrics
+    >>> from pybliometrics.scival import AuthorMetrics
+    >>> pybliometrics.scival.init()
+    >>> author_metrics = AuthorMetrics("6602819806")
+
+You can obtain basic information just by printing the object:
+
+.. code-block:: python
+
+    >>> print(author_metrics)
+    AuthorMetrics for 1 author(s):
+    - Algül, Hana (ID: 6602819806)
+
+There are many properties available that provide different types of metrics. You can explore the available authors:
+
+.. code-block:: python
+
+    >>> author_metrics.authors
+    [Author(id=6602819806, name='Algül, Hana', uri='Author/6602819806')]
+
+**Individual Metric Properties**
+
+Each metric property returns a list of `MetricData` namedtuples with the structure: `(author_id, author_name, metric, metric_type, year, value, percentage, threshold)`.
+
+.. code-block:: python
+
+    >>> author_metrics.CitationCount
+    [MetricData(author_id=6602819806, author_name='Algül, Hana', metric='CitationCount', 
+                metric_type='Citation count', year='all', value=1234, percentage=85.5, threshold=None)]
+
+    >>> author_metrics.HIndices
+    [MetricData(author_id=6602819806, author_name='Algül, Hana', metric='HIndices', 
+                metric_type='h-index', year='all', value=46.0, percentage=None, threshold=None)]
+
+**Available Metric Properties**:
+
+- `AcademicCorporateCollaboration`
+- `AcademicCorporateCollaborationImpact`
+- `CitationCount`
+- `CitationsPerPublication`
+- `CitedPublications`
+- `Collaboration`
+- `CollaborationImpact`
+- `FieldWeightedCitationImpact`
+- `HIndices` (only available when `by_year=False`)
+- `OutputsInTopCitationPercentiles`
+- `PublicationsInTopJournalPercentiles`
+- `ScholarlyOutput`
+
+**Getting All Metrics at Once**
+
+You can retrieve all available metrics in a single list using the `all_metrics` property:
+
+.. code-block:: python
+
+    >>> all_data = author_metrics.all_metrics
+    >>> len(all_data)
+    29
+    >>> # Convert to pandas DataFrame for analysis
+    >>> import pandas as pd
+    >>> df = pd.DataFrame(all_data)
+    >>> df.head()
+
+
+.. raw:: html
+
+    <div style="overflow-x:auto; border:1px solid #ddd; padding:10px;">
+    <style scoped>
+        .dataframe tbody tr th:only-of-type {
+            vertical-align: middle;
+        }
+
+        .dataframe tbody tr th {
+            vertical-align: top;
+        }
+
+        .dataframe thead th {
+            text-align: right;
+        }
+        .dataframe{
+            font-size: 12px;
+        }
+    </style>
+    <table border="1" class="dataframe">
+    <thead>
+        <tr style="text-align: right;">
+        <th></th>
+        <th>author_id</th>
+        <th>author_name</th>
+        <th>metric</th>
+        <th>metric_type</th>
+        <th>year</th>
+        <th>value</th>
+        <th>percentage</th>
+        <th>threshold</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+        <th>0</th>
+        <td>6602819806</td>
+        <td>Algül, Hana</td>
+        <td>AcademicCorporateCollaboration</td>
+        <td>Academic-corporate collaboration</td>
+        <td>all</td>
+        <td>12.000000</td>
+        <td>22.64151</td>
+        <td>NaN</td>
+        </tr>
+        <tr>
+        <th>1</th>
+        <td>6602819806</td>
+        <td>Algül, Hana</td>
+        <td>AcademicCorporateCollaboration</td>
+        <td>No academic-corporate collaboration</td>
+        <td>all</td>
+        <td>41.000000</td>
+        <td>77.35849</td>
+        <td>NaN</td>
+        </tr>
+        <tr>
+        <th>2</th>
+        <td>6602819806</td>
+        <td>Algül, Hana</td>
+        <td>AcademicCorporateCollaborationImpact</td>
+        <td>Academic-corporate collaboration</td>
+        <td>all</td>
+        <td>43.166668</td>
+        <td>NaN</td>
+        <td>NaN</td>
+        </tr>
+        <tr>
+        <th>3</th>
+        <td>6602819806</td>
+        <td>Algül, Hana</td>
+        <td>AcademicCorporateCollaborationImpact</td>
+        <td>No academic-corporate collaboration</td>
+        <td>all</td>
+        <td>14.682927</td>
+        <td>NaN</td>
+        <td>NaN</td>
+        </tr>
+        <tr>
+        <th>4</th>
+        <td>6602819806</td>
+        <td>Algül, Hana</td>
+        <td>Collaboration</td>
+        <td>Institutional collaboration</td>
+        <td>all</td>
+        <td>6.000000</td>
+        <td>11.32000</td>
+        <td>NaN</td>
+        </tr>
+    </tbody>
+    </table>
+    </div>
+
+
+**Multiple Authors**
+
+You can analyze multiple authors simultaneously. Furthermore, you can specify whether you want metrics broken down by year or not. If `by_year=True`, each metric will be returned for each year separately.
+
+.. code-block:: python
+
+    >>> multi_authors = AuthorMetrics([7201667143, 6603480302], by_year=True)
+    >>> print(multi_authors)
+    AuthorMetrics for 2 author(s):
+    - Wolff, Klaus Dietrich (ID: 7201667143)
+    - Vogel-Heuser, Birgit (ID: 6603480302)
+    >>> df = pd.DataFrame(multi_authors.all_metrics)
+    >>> df.tail(5)
+
+
+.. raw:: html
+
+    <div style="overflow-x:auto; border:1px solid #ddd; padding:10px;">
+    <style scoped>
+        .dataframe tbody tr th:only-of-type {
+            vertical-align: middle;
+        }
+
+        .dataframe tbody tr th {
+            vertical-align: top;
+        }
+
+        .dataframe thead th {
+            text-align: right;
+        }
+        .dataframe{
+            font-size: 12px;
+        }
+    </style>
+    <table border="1" class="dataframe">
+    <thead>
+        <tr style="text-align: right;">
+        <th></th>
+        <th>author_id</th>
+        <th>author_name</th>
+        <th>metric</th>
+        <th>metric_type</th>
+        <th>year</th>
+        <th>value</th>
+        <th>percentage</th>
+        <th>threshold</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+        <th>275</th>
+        <td>6603480302</td>
+        <td>Vogel-Heuser, Birgit</td>
+        <td>OutputsInTopCitationPercentiles</td>
+        <td>None</td>
+        <td>2024</td>
+        <td>5.0</td>
+        <td>13.157895</td>
+        <td>25.0</td>
+        </tr>
+        <tr>
+        <th>276</th>
+        <td>6603480302</td>
+        <td>Vogel-Heuser, Birgit</td>
+        <td>OutputsInTopCitationPercentiles</td>
+        <td>None</td>
+        <td>2020</td>
+        <td>5.0</td>
+        <td>10.000000</td>
+        <td>25.0</td>
+        </tr>
+        <tr>
+        <th>277</th>
+        <td>6603480302</td>
+        <td>Vogel-Heuser, Birgit</td>
+        <td>OutputsInTopCitationPercentiles</td>
+        <td>None</td>
+        <td>2021</td>
+        <td>14.0</td>
+        <td>27.450981</td>
+        <td>25.0</td>
+        </tr>
+        <tr>
+        <th>278</th>
+        <td>6603480302</td>
+        <td>Vogel-Heuser, Birgit</td>
+        <td>OutputsInTopCitationPercentiles</td>
+        <td>None</td>
+        <td>2022</td>
+        <td>8.0</td>
+        <td>24.242424</td>
+        <td>25.0</td>
+        </tr>
+        <tr>
+        <th>279</th>
+        <td>6603480302</td>
+        <td>Vogel-Heuser, Birgit</td>
+        <td>OutputsInTopCitationPercentiles</td>
+        <td>None</td>
+        <td>2023</td>
+        <td>1.0</td>
+        <td>2.173913</td>
+        <td>25.0</td>
+        </tr>
+    </tbody>
+    </table>
+    </div>
+
+
+**Filtering Specific Metrics**
+
+You can request only specific metrics to reduce API response size:
+
+.. code-block:: python
+
+    >>> h_index_only = AuthorMetrics("6602819806", metric_types=["HIndices"])
+    >>> h_index_only.HIndices
+    [MetricData(author_id=6602819806, author_name='Algül, Hana', metric='HIndices', 
+                metric_type='h-index', year='all', value=46.0, percentage=None, threshold=None)]
+
+    >>> # Multiple specific metrics
+    >>> selected_metrics = AuthorMetrics("6602819806", 
+    ...                                  metric_types=["CitationCount", "ScholarlyOutput"])
+
+
+Downloaded results are cached to expedite subsequent analyses. This information may become outdated. To refresh the cached results if they exist, set `refresh=True`, or provide an integer that will be interpreted as the maximum allowed number of days since the last modification date. For example, if you want to refresh all cached results older than 100 days, set `refresh=100`. Use `author_metrics.get_cache_file_mdate()` to obtain the date of last modification, and `author_metrics.get_cache_file_age()` to determine the number of days since the last modification.

--- a/docs/reference/scival/AuthorMetrics.rst
+++ b/docs/reference/scival/AuthorMetrics.rst
@@ -45,16 +45,16 @@ There are many properties available that provide different types of metrics. You
 
 **Individual Metric Properties**
 
-Each metric property returns a list of `MetricData` namedtuples with the structure: `(author_id, author_name, metric, metric_type, year, value, percentage, threshold)`.
+Each metric property returns a list of `MetricData` namedtuples with the structure: `(entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)` where `entity_id` and `entity_name` refer to the author.
 
 .. code-block:: python
 
     >>> author_metrics.CitationCount
-    [MetricData(author_id=6602819806, author_name='Algül, Hana', metric='CitationCount', 
+    [MetricData(entity_id=6602819806, entity_name='Algül, Hana', metric='CitationCount', 
                 metric_type='Citation count', year='all', value=1234, percentage=85.5, threshold=None)]
 
     >>> author_metrics.HIndices
-    [MetricData(author_id=6602819806, author_name='Algül, Hana', metric='HIndices', 
+    [MetricData(entity_id=6602819806, entity_name='Algül, Hana', metric='HIndices', 
                 metric_type='h-index', year='all', value=46.0, percentage=None, threshold=None)]
 
 **Available Metric Properties**:
@@ -71,6 +71,9 @@ Each metric property returns a list of `MetricData` namedtuples with the structu
 - `OutputsInTopCitationPercentiles`
 - `PublicationsInTopJournalPercentiles`
 - `ScholarlyOutput`
+
+.. note::
+   **Unified Data Structure**: AuthorMetrics uses a unified `MetricData` structure with `entity_id` and `entity_name` fields. For authors, these fields contain the author ID and author name respectively. This structure is compatible with `InstitutionMetrics` and other SciVal metric classes, enabling consistent data analysis across different entity types.
 
 **Getting All Metrics at Once**
 
@@ -110,8 +113,8 @@ You can retrieve all available metrics in a single list using the `all_metrics` 
     <thead>
         <tr style="text-align: right;">
         <th></th>
-        <th>author_id</th>
-        <th>author_name</th>
+        <th>entity_id</th>
+        <th>entity_name</th>
         <th>metric</th>
         <th>metric_type</th>
         <th>year</th>
@@ -219,8 +222,8 @@ You can analyze multiple authors simultaneously. Furthermore, you can specify wh
     <thead>
         <tr style="text-align: right;">
         <th></th>
-        <th>author_id</th>
-        <th>author_name</th>
+        <th>entity_id</th>
+        <th>entity_name</th>
         <th>metric</th>
         <th>metric_type</th>
         <th>year</th>
@@ -298,7 +301,7 @@ You can request only specific metrics to reduce API response size:
 
     >>> h_index_only = AuthorMetrics("6602819806", metric_types=["HIndices"])
     >>> h_index_only.HIndices
-    [MetricData(author_id=6602819806, author_name='Algül, Hana', metric='HIndices', 
+    [MetricData(entity_id=6602819806, entity_name='Algül, Hana', metric='HIndices', 
                 metric_type='h-index', year='all', value=46.0, percentage=None, threshold=None)]
 
     >>> # Multiple specific metrics

--- a/docs/reference/scival/AuthorMetrics.rst
+++ b/docs/reference/scival/AuthorMetrics.rst
@@ -25,7 +25,7 @@ You initialize the class with one or more Scopus Author IDs. The argument can be
 
     >>> from pybliometrics.scival import AuthorMetrics, init
     >>> init()
-    >>> author_metrics = AuthorMetrics("6602819806")
+    >>> author_metrics = AuthorMetrics("57209617104")
 
 You can obtain basic information just by printing the object:
 
@@ -33,14 +33,14 @@ You can obtain basic information just by printing the object:
 
     >>> print(author_metrics)
     AuthorMetrics for 1 author(s):
-    - Algül, Hana (ID: 6602819806)
+    - Rose, Michael E. (ID: 57209617104)
 
 There are many properties available that provide different types of metrics. You can explore the available authors:
 
 .. code-block:: python
 
     >>> author_metrics.authors
-    [Author(id=6602819806, name='Algül, Hana', uri='Author/6602819806')]
+    [Author(id=57209617104, name='Rose, Michael E.', uri='Author/57209617104')]
 
 **Individual Metric Properties**
 
@@ -49,10 +49,10 @@ Each metric property returns a list of `MetricData` namedtuples with the structu
 .. code-block:: python
 
     >>> author_metrics.CitationCount
-    [MetricData(entity_id=6602819806, entity_name='Algül, Hana', metric='CitationCount', metric_type='CitationCount', year='all', value=1120, percentage=None, threshold=None)]
+    [MetricData(entity_id=57209617104, entity_name='Rose, Michael E.', metric='CitationCount', metric_type='CitationCount', year='all', value=92, percentage=None, threshold=None)]
 
     >>> author_metrics.HIndices
-    [MetricData(entity_id=6602819806, entity_name='Algül, Hana', metric='h-index', metric_type='HIndices', year='all', value=46.0, percentage=None, threshold=None)]
+    [MetricData(entity_id=57209617104, entity_name='Rose, Michael E.', metric='h-index', metric_type='HIndices', year='all', value=5.0, percentage=None, threshold=None)]
 
 **Available Metric Properties**:
 
@@ -122,42 +122,31 @@ Metrics can be concatenated and converted into a pandas DataFrame for easier ana
     <tbody>
         <tr>
         <th>0</th>
-        <td>6602819806</td>
-        <td>Algül, Hana</td>
+        <td>57209617104</td>
+        <td>Rose, Michael E.</td>
         <td>Institutional collaboration</td>
         <td>Collaboration</td>
         <td>all</td>
-        <td>6.000000</td>
-        <td>11.32</td>
+        <td>1.000000</td>
+        <td>11.11</td>
         <td>None</td>
         </tr>
         <tr>
         <th>1</th>
-        <td>6602819806</td>
-        <td>Algül, Hana</td>
+        <td>57209617104</td>
+        <td>Rose, Michael E.</td>
         <td>International collaboration</td>
         <td>Collaboration</td>
         <td>all</td>
-        <td>26.000000</td>
-        <td>49.06</td>
+        <td>7.000000</td>
+        <td>77.78</td>
         <td>None</td>
         </tr>
         <tr>
         <th>2</th>
-        <td>6602819806</td>
-        <td>Algül, Hana</td>
+        <td>57209617104</td>
+        <td>Rose, Michael E.</td>
         <td>National collaboration</td>
-        <td>Collaboration</td>
-        <td>all</td>
-        <td>21.000000</td>
-        <td>39.62</td>
-        <td>None</td>
-        </tr>
-        <tr>
-        <th>3</th>
-        <td>6602819806</td>
-        <td>Algül, Hana</td>
-        <td>Single authorship</td>
         <td>Collaboration</td>
         <td>all</td>
         <td>0.000000</td>
@@ -165,46 +154,57 @@ Metrics can be concatenated and converted into a pandas DataFrame for easier ana
         <td>None</td>
         </tr>
         <tr>
+        <th>3</th>
+        <td>57209617104</td>
+        <td>Rose, Michael E.</td>
+        <td>Single authorship</td>
+        <td>Collaboration</td>
+        <td>all</td>
+        <td>1.000000</td>
+        <td>11.11</td>
+        <td>None</td>
+        </tr>
+        <tr>
         <th>4</th>
-        <td>6602819806</td>
-        <td>Algül, Hana</td>
+        <td>57209617104</td>
+        <td>Rose, Michael E.</td>
         <td>Institutional collaboration</td>
         <td>CollaborationImpact</td>
         <td>all</td>
-        <td>3.500000</td>
+        <td>0.000000</td>
         <td>NaN</td>
         <td>None</td>
         </tr>
         <tr>
         <th>5</th>
-        <td>6602819806</td>
-        <td>Algül, Hana</td>
+        <td>57209617104</td>
+        <td>Rose, Michael E.</td>
         <td>International collaboration</td>
         <td>CollaborationImpact</td>
         <td>all</td>
-        <td>28.461538</td>
+        <td>12.571428</td>
         <td>NaN</td>
         <td>None</td>
         </tr>
         <tr>
         <th>6</th>
-        <td>6602819806</td>
-        <td>Algül, Hana</td>
+        <td>57209617104</td>
+        <td>Rose, Michael E.</td>
         <td>National collaboration</td>
         <td>CollaborationImpact</td>
         <td>all</td>
-        <td>17.095238</td>
+        <td>0.000000</td>
         <td>NaN</td>
         <td>None</td>
         </tr>
         <tr>
         <th>7</th>
-        <td>6602819806</td>
-        <td>Algül, Hana</td>
+        <td>57209617104</td>
+        <td>Rose, Michael E.</td>
         <td>Single authorship</td>
         <td>CollaborationImpact</td>
         <td>all</td>
-        <td>0.000000</td>
+        <td>4.000000</td>
         <td>NaN</td>
         <td>None</td>
         </tr>
@@ -219,11 +219,11 @@ You can analyze multiple authors simultaneously. Furthermore, you can specify wh
 
 .. code-block:: python
 
-    >>> multi_authors = AuthorMetrics([7201667143, 6603480302], by_year=True)
+    >>> multi_authors = AuthorMetrics([57209617104, 7004212771], by_year=True)
     >>> print(multi_authors)
     AuthorMetrics for 2 author(s):
-    - Wolff, Klaus Dietrich (ID: 7201667143)
-    - Vogel-Heuser, Birgit (ID: 6603480302)
+    - Kitchin, John R. (ID: 7004212771)
+    - Rose, Michael E. (ID: 57209617104)
     >>> # Create a DataFrame from the Collaboration metrics
     >>> df_multi = pd.DataFrame(multi_authors.Collaboration)
     >>> df_multi.head()
@@ -266,57 +266,57 @@ You can analyze multiple authors simultaneously. Furthermore, you can specify wh
     <tbody>
         <tr>
         <th>0</th>
-        <td>7201667143</td>
-        <td>Wolff, Klaus Dietrich</td>
+        <td>7004212771</td>
+        <td>Kitchin, John R.</td>
         <td>Institutional collaboration</td>
         <td>Collaboration</td>
         <td>2024</td>
-        <td>3</td>
-        <td>30.000002</td>
+        <td>6</td>
+        <td>37.500000</td>
         <td>None</td>
         </tr>
         <tr>
         <th>1</th>
-        <td>7201667143</td>
-        <td>Wolff, Klaus Dietrich</td>
+        <td>7004212771</td>
+        <td>Kitchin, John R.</td>
         <td>Institutional collaboration</td>
         <td>Collaboration</td>
         <td>2020</td>
-        <td>3</td>
-        <td>16.666668</td>
+        <td>1</td>
+        <td>50.000000</td>
         <td>None</td>
         </tr>
         <tr>
         <th>2</th>
-        <td>7201667143</td>
-        <td>Wolff, Klaus Dietrich</td>
+        <td>7004212771</td>
+        <td>Kitchin, John R.</td>
         <td>Institutional collaboration</td>
         <td>Collaboration</td>
         <td>2021</td>
-        <td>2</td>
-        <td>25.000000</td>
+        <td>1</td>
+        <td>33.333336</td>
         <td>None</td>
         </tr>
         <tr>
         <th>3</th>
-        <td>7201667143</td>
-        <td>Wolff, Klaus Dietrich</td>
+        <td>7004212771</td>
+        <td>Kitchin, John R.</td>
         <td>Institutional collaboration</td>
         <td>Collaboration</td>
         <td>2022</td>
-        <td>0</td>
-        <td>0.000000</td>
+        <td>6</td>
+        <td>66.666670</td>
         <td>None</td>
         </tr>
         <tr>
         <th>4</th>
-        <td>7201667143</td>
-        <td>Wolff, Klaus Dietrich</td>
+        <td>7004212771</td>
+        <td>Kitchin, John R.</td>
         <td>Institutional collaboration</td>
         <td>Collaboration</td>
         <td>2023</td>
-        <td>4</td>
-        <td>30.769232</td>
+        <td>5</td>
+        <td>55.555557</td>
         <td>None</td>
         </tr>
     </tbody>
@@ -331,14 +331,14 @@ You can request only specific metrics to reduce API response size:
 
 .. code-block:: python
 
-    >>> h_index_only = AuthorMetrics("6602819806", metric_types=["HIndices"])
+    >>> h_index_only = AuthorMetrics("57209617104", metric_types=["HIndices"])
     >>> h_index_only.HIndices
-    [MetricData(entity_id=6602819806, entity_name='Algül, Hana', metric='h-index', metric_type='HIndices', year='all', value=46.0, percentage=None, threshold=None)]
+    [MetricData(entity_id=57209617104, entity_name='Rose, Michael E.', metric='h-index', metric_type='HIndices', year='all', value=5.0, percentage=None, threshold=None)]
 
     >>> # Multiple specific metrics
-    >>> selected_metrics = AuthorMetrics("6602819806", metric_types=["CitationCount", "ScholarlyOutput"])
+    >>> selected_metrics = AuthorMetrics("57209617104", metric_types=["CitationCount", "ScholarlyOutput"])
     >>> selected_metrics.CitationCount
-    [MetricData(entity_id=6602819806, entity_name='Algül, Hana', metric='CitationCount', metric_type='CitationCount', year='all', value=1126, percentage=None, threshold=None)]
+    [MetricData(entity_id=57209617104, entity_name='Rose, Michael E.', metric='CitationCount', metric_type='CitationCount', year='all', value=92, percentage=None, threshold=None)]
 
 
 Downloaded results are cached to expedite subsequent analyses. This information may become outdated. To refresh the cached results if they exist, set `refresh=True`, or provide an integer that will be interpreted as the maximum allowed number of days since the last modification date. For example, if you want to refresh all cached results older than 100 days, set `refresh=100`. Use `author_metrics.get_cache_file_mdate()` to obtain the date of last modification, and `author_metrics.get_cache_file_age()` to determine the number of days since the last modification.

--- a/docs/reference/scival/AuthorMetrics.rst
+++ b/docs/reference/scival/AuthorMetrics.rst
@@ -23,9 +23,8 @@ You initialize the class with one or more Scopus Author IDs. The argument can be
 
 .. code-block:: python
 
-    >>> import pybliometrics
-    >>> from pybliometrics.scival import AuthorMetrics
-    >>> pybliometrics.scival.init()
+    >>> from pybliometrics.scival import AuthorMetrics, init
+    >>> init()
     >>> author_metrics = AuthorMetrics("6602819806")
 
 You can obtain basic information just by printing the object:
@@ -50,12 +49,10 @@ Each metric property returns a list of `MetricData` namedtuples with the structu
 .. code-block:: python
 
     >>> author_metrics.CitationCount
-    [MetricData(entity_id=6602819806, entity_name='Algül, Hana', metric='CitationCount', 
-                metric_type='Citation count', year='all', value=1234, percentage=85.5, threshold=None)]
+    [MetricData(entity_id=6602819806, entity_name='Algül, Hana', metric='CitationCount', metric_type='CitationCount', year='all', value=1120, percentage=None, threshold=None)]
 
     >>> author_metrics.HIndices
-    [MetricData(entity_id=6602819806, entity_name='Algül, Hana', metric='HIndices', 
-                metric_type='h-index', year='all', value=46.0, percentage=None, threshold=None)]
+    [MetricData(entity_id=6602819806, entity_name='Algül, Hana', metric='h-index', metric_type='HIndices', year='all', value=46.0, percentage=None, threshold=None)]
 
 **Available Metric Properties**:
 
@@ -128,8 +125,8 @@ You can retrieve all available metrics in a single list using the `all_metrics` 
         <th>0</th>
         <td>6602819806</td>
         <td>Algül, Hana</td>
-        <td>AcademicCorporateCollaboration</td>
         <td>Academic-corporate collaboration</td>
+        <td>AcademicCorporateCollaboration</td>
         <td>all</td>
         <td>12.000000</td>
         <td>22.64151</td>
@@ -139,8 +136,8 @@ You can retrieve all available metrics in a single list using the `all_metrics` 
         <th>1</th>
         <td>6602819806</td>
         <td>Algül, Hana</td>
-        <td>AcademicCorporateCollaboration</td>
         <td>No academic-corporate collaboration</td>
+        <td>AcademicCorporateCollaboration</td>
         <td>all</td>
         <td>41.000000</td>
         <td>77.35849</td>
@@ -150,8 +147,8 @@ You can retrieve all available metrics in a single list using the `all_metrics` 
         <th>2</th>
         <td>6602819806</td>
         <td>Algül, Hana</td>
-        <td>AcademicCorporateCollaborationImpact</td>
         <td>Academic-corporate collaboration</td>
+        <td>AcademicCorporateCollaborationImpact</td>
         <td>all</td>
         <td>43.166668</td>
         <td>NaN</td>
@@ -161,8 +158,8 @@ You can retrieve all available metrics in a single list using the `all_metrics` 
         <th>3</th>
         <td>6602819806</td>
         <td>Algül, Hana</td>
-        <td>AcademicCorporateCollaborationImpact</td>
         <td>No academic-corporate collaboration</td>
+        <td>AcademicCorporateCollaborationImpact</td>
         <td>all</td>
         <td>14.682927</td>
         <td>NaN</td>
@@ -172,8 +169,8 @@ You can retrieve all available metrics in a single list using the `all_metrics` 
         <th>4</th>
         <td>6602819806</td>
         <td>Algül, Hana</td>
-        <td>Collaboration</td>
         <td>Institutional collaboration</td>
+        <td>Collaboration</td>
         <td>all</td>
         <td>6.000000</td>
         <td>11.32000</td>
@@ -196,7 +193,7 @@ You can analyze multiple authors simultaneously. Furthermore, you can specify wh
     - Wolff, Klaus Dietrich (ID: 7201667143)
     - Vogel-Heuser, Birgit (ID: 6603480302)
     >>> df = pd.DataFrame(multi_authors.all_metrics)
-    >>> df.tail(5)
+    >>> df.tail()
 
 
 .. raw:: html
@@ -238,7 +235,7 @@ You can analyze multiple authors simultaneously. Furthermore, you can specify wh
         <td>6603480302</td>
         <td>Vogel-Heuser, Birgit</td>
         <td>OutputsInTopCitationPercentiles</td>
-        <td>None</td>
+        <td>OutputsInTopCitationPercentiles</td>
         <td>2024</td>
         <td>5.0</td>
         <td>13.157895</td>
@@ -249,7 +246,7 @@ You can analyze multiple authors simultaneously. Furthermore, you can specify wh
         <td>6603480302</td>
         <td>Vogel-Heuser, Birgit</td>
         <td>OutputsInTopCitationPercentiles</td>
-        <td>None</td>
+        <td>OutputsInTopCitationPercentiles</td>
         <td>2020</td>
         <td>5.0</td>
         <td>10.000000</td>
@@ -260,7 +257,7 @@ You can analyze multiple authors simultaneously. Furthermore, you can specify wh
         <td>6603480302</td>
         <td>Vogel-Heuser, Birgit</td>
         <td>OutputsInTopCitationPercentiles</td>
-        <td>None</td>
+        <td>OutputsInTopCitationPercentiles</td>
         <td>2021</td>
         <td>14.0</td>
         <td>27.450981</td>
@@ -271,7 +268,7 @@ You can analyze multiple authors simultaneously. Furthermore, you can specify wh
         <td>6603480302</td>
         <td>Vogel-Heuser, Birgit</td>
         <td>OutputsInTopCitationPercentiles</td>
-        <td>None</td>
+        <td>OutputsInTopCitationPercentiles</td>
         <td>2022</td>
         <td>8.0</td>
         <td>24.242424</td>
@@ -282,7 +279,7 @@ You can analyze multiple authors simultaneously. Furthermore, you can specify wh
         <td>6603480302</td>
         <td>Vogel-Heuser, Birgit</td>
         <td>OutputsInTopCitationPercentiles</td>
-        <td>None</td>
+        <td>OutputsInTopCitationPercentiles</td>
         <td>2023</td>
         <td>1.0</td>
         <td>2.173913</td>
@@ -301,12 +298,12 @@ You can request only specific metrics to reduce API response size:
 
     >>> h_index_only = AuthorMetrics("6602819806", metric_types=["HIndices"])
     >>> h_index_only.HIndices
-    [MetricData(entity_id=6602819806, entity_name='Algül, Hana', metric='HIndices', 
-                metric_type='h-index', year='all', value=46.0, percentage=None, threshold=None)]
+    [MetricData(entity_id=6602819806, entity_name='Algül, Hana', metric='h-index', metric_type='HIndices', year='all', value=46.0, percentage=None, threshold=None)]
 
     >>> # Multiple specific metrics
-    >>> selected_metrics = AuthorMetrics("6602819806", 
-    ...                                  metric_types=["CitationCount", "ScholarlyOutput"])
+    >>> selected_metrics = AuthorMetrics("6602819806", metric_types=["CitationCount", "ScholarlyOutput"])
+    >>> selected_metrics.CitationCount
+    [MetricData(entity_id=6602819806, entity_name='Algül, Hana', metric='CitationCount', metric_type='CitationCount', year='all', value=1126, percentage=None, threshold=None)]
 
 
 Downloaded results are cached to expedite subsequent analyses. This information may become outdated. To refresh the cached results if they exist, set `refresh=True`, or provide an integer that will be interpreted as the maximum allowed number of days since the last modification date. For example, if you want to refresh all cached results older than 100 days, set `refresh=100`. Use `author_metrics.get_cache_file_mdate()` to obtain the date of last modification, and `author_metrics.get_cache_file_age()` to determine the number of days since the last modification.

--- a/docs/reference/scival/AuthorMetrics.rst
+++ b/docs/reference/scival/AuthorMetrics.rst
@@ -44,15 +44,15 @@ There are many properties available that provide different types of metrics. You
 
 **Individual Metric Properties**
 
-Each metric property returns a list of `MetricData` namedtuples with the structure: `(entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)` where `entity_id` and `entity_name` refer to the author.
+Each metric property returns a list of `MetricData` namedtuples with the structure: `(entity_id, entity_name, metric, year, value, percentage, threshold)` where `entity_id` and `entity_name` refer to the author.
 
 .. code-block:: python
 
     >>> author_metrics.CitationCount
-    [MetricData(entity_id=57209617104, entity_name='Rose, Michael E.', metric='CitationCount', metric_type='CitationCount', year='all', value=92, percentage=None, threshold=None)]
+    [MetricData(entity_id=57209617104, entity_name='Rose, Michael E.', metric='CitationCount', year='all', value=92, percentage=None, threshold=None)]
 
     >>> author_metrics.HIndices
-    [MetricData(entity_id=57209617104, entity_name='Rose, Michael E.', metric='h-index', metric_type='HIndices', year='all', value=5.0, percentage=None, threshold=None)]
+    [MetricData(entity_id=57209617104, entity_name='Rose, Michael E.', metric='h-index', year='all', value=5.0, percentage=None, threshold=None)]
 
 **Available Metric Properties**:
 
@@ -112,7 +112,6 @@ Metrics can be concatenated and converted into a pandas DataFrame for easier ana
         <th>entity_id</th>
         <th>entity_name</th>
         <th>metric</th>
-        <th>metric_type</th>
         <th>year</th>
         <th>value</th>
         <th>percentage</th>
@@ -125,7 +124,6 @@ Metrics can be concatenated and converted into a pandas DataFrame for easier ana
         <td>57209617104</td>
         <td>Rose, Michael E.</td>
         <td>Institutional collaboration</td>
-        <td>Collaboration</td>
         <td>all</td>
         <td>1.000000</td>
         <td>11.11</td>
@@ -136,7 +134,6 @@ Metrics can be concatenated and converted into a pandas DataFrame for easier ana
         <td>57209617104</td>
         <td>Rose, Michael E.</td>
         <td>International collaboration</td>
-        <td>Collaboration</td>
         <td>all</td>
         <td>7.000000</td>
         <td>77.78</td>
@@ -147,7 +144,6 @@ Metrics can be concatenated and converted into a pandas DataFrame for easier ana
         <td>57209617104</td>
         <td>Rose, Michael E.</td>
         <td>National collaboration</td>
-        <td>Collaboration</td>
         <td>all</td>
         <td>0.000000</td>
         <td>0.00</td>
@@ -158,7 +154,6 @@ Metrics can be concatenated and converted into a pandas DataFrame for easier ana
         <td>57209617104</td>
         <td>Rose, Michael E.</td>
         <td>Single authorship</td>
-        <td>Collaboration</td>
         <td>all</td>
         <td>1.000000</td>
         <td>11.11</td>
@@ -169,7 +164,6 @@ Metrics can be concatenated and converted into a pandas DataFrame for easier ana
         <td>57209617104</td>
         <td>Rose, Michael E.</td>
         <td>Institutional collaboration</td>
-        <td>CollaborationImpact</td>
         <td>all</td>
         <td>0.000000</td>
         <td>NaN</td>
@@ -180,7 +174,6 @@ Metrics can be concatenated and converted into a pandas DataFrame for easier ana
         <td>57209617104</td>
         <td>Rose, Michael E.</td>
         <td>International collaboration</td>
-        <td>CollaborationImpact</td>
         <td>all</td>
         <td>12.571428</td>
         <td>NaN</td>
@@ -191,7 +184,6 @@ Metrics can be concatenated and converted into a pandas DataFrame for easier ana
         <td>57209617104</td>
         <td>Rose, Michael E.</td>
         <td>National collaboration</td>
-        <td>CollaborationImpact</td>
         <td>all</td>
         <td>0.000000</td>
         <td>NaN</td>
@@ -202,7 +194,6 @@ Metrics can be concatenated and converted into a pandas DataFrame for easier ana
         <td>57209617104</td>
         <td>Rose, Michael E.</td>
         <td>Single authorship</td>
-        <td>CollaborationImpact</td>
         <td>all</td>
         <td>4.000000</td>
         <td>NaN</td>
@@ -256,7 +247,6 @@ You can analyze multiple authors simultaneously. Furthermore, you can specify wh
         <th>entity_id</th>
         <th>entity_name</th>
         <th>metric</th>
-        <th>metric_type</th>
         <th>year</th>
         <th>value</th>
         <th>percentage</th>
@@ -269,7 +259,6 @@ You can analyze multiple authors simultaneously. Furthermore, you can specify wh
         <td>7004212771</td>
         <td>Kitchin, John R.</td>
         <td>Institutional collaboration</td>
-        <td>Collaboration</td>
         <td>2024</td>
         <td>6</td>
         <td>37.500000</td>
@@ -280,7 +269,6 @@ You can analyze multiple authors simultaneously. Furthermore, you can specify wh
         <td>7004212771</td>
         <td>Kitchin, John R.</td>
         <td>Institutional collaboration</td>
-        <td>Collaboration</td>
         <td>2020</td>
         <td>1</td>
         <td>50.000000</td>
@@ -291,7 +279,6 @@ You can analyze multiple authors simultaneously. Furthermore, you can specify wh
         <td>7004212771</td>
         <td>Kitchin, John R.</td>
         <td>Institutional collaboration</td>
-        <td>Collaboration</td>
         <td>2021</td>
         <td>1</td>
         <td>33.333336</td>
@@ -302,7 +289,6 @@ You can analyze multiple authors simultaneously. Furthermore, you can specify wh
         <td>7004212771</td>
         <td>Kitchin, John R.</td>
         <td>Institutional collaboration</td>
-        <td>Collaboration</td>
         <td>2022</td>
         <td>6</td>
         <td>66.666670</td>
@@ -313,7 +299,6 @@ You can analyze multiple authors simultaneously. Furthermore, you can specify wh
         <td>7004212771</td>
         <td>Kitchin, John R.</td>
         <td>Institutional collaboration</td>
-        <td>Collaboration</td>
         <td>2023</td>
         <td>5</td>
         <td>55.555557</td>
@@ -333,12 +318,12 @@ You can request only specific metrics to reduce API response size:
 
     >>> h_index_only = AuthorMetrics("57209617104", metric_types=["HIndices"])
     >>> h_index_only.HIndices
-    [MetricData(entity_id=57209617104, entity_name='Rose, Michael E.', metric='h-index', metric_type='HIndices', year='all', value=5.0, percentage=None, threshold=None)]
+    [MetricData(entity_id=57209617104, entity_name='Rose, Michael E.', metric='h-index', year='all', value=5.0, percentage=None, threshold=None)]
 
     >>> # Multiple specific metrics
     >>> selected_metrics = AuthorMetrics("57209617104", metric_types=["CitationCount", "ScholarlyOutput"])
     >>> selected_metrics.CitationCount
-    [MetricData(entity_id=57209617104, entity_name='Rose, Michael E.', metric='CitationCount', metric_type='CitationCount', year='all', value=92, percentage=None, threshold=None)]
+    [MetricData(entity_id=57209617104, entity_name='Rose, Michael E.', metric='CitationCount', year='all', value=92, percentage=None, threshold=None)]
 
 
 Downloaded results are cached to expedite subsequent analyses. This information may become outdated. To refresh the cached results if they exist, set `refresh=True`, or provide an integer that will be interpreted as the maximum allowed number of days since the last modification date. For example, if you want to refresh all cached results older than 100 days, set `refresh=100`. Use `author_metrics.get_cache_file_mdate()` to obtain the date of last modification, and `author_metrics.get_cache_file_age()` to determine the number of days since the last modification.

--- a/pybliometrics/scival/__init__.py
+++ b/pybliometrics/scival/__init__.py
@@ -1,3 +1,4 @@
 from pybliometrics.utils import *
 
+from pybliometrics.scival.author_metrics import *
 from pybliometrics.scival.publication_lookup import *

--- a/pybliometrics/scival/author_metrics.py
+++ b/pybliometrics/scival/author_metrics.py
@@ -1,0 +1,224 @@
+from collections import namedtuple
+from typing import Union, Optional
+
+from pybliometrics.superclasses import Retrieval
+from pybliometrics.utils import make_int_if_possible
+from pybliometrics.utils.constants import SCIVAL_METRICS
+from pybliometrics.utils.parse_metrics import extract_metric_data
+
+
+class AuthorMetrics(Retrieval):
+    @property  
+    def AcademicCorporateCollaboration(self) -> Optional[list]:
+        """Academic corporate collaboration metrics for each author.
+        Returns list of MetricData namedtuples with unified structure:
+        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        """
+        return extract_metric_data(self._json, 'AcademicCorporateCollaboration', self._by_year)
+
+    @property
+    def AcademicCorporateCollaborationImpact(self) -> Optional[list]:
+        """Academic corporate collaboration impact metrics for each author.
+        Returns list of MetricData namedtuples with unified structure:
+        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        """
+        return extract_metric_data(self._json, 'AcademicCorporateCollaborationImpact', self._by_year)
+
+    @property
+    def all_metrics(self) -> Optional[list]:
+        """Get all available metrics concatenated into a single list.
+        Returns list of MetricData namedtuples with unified structure:
+        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        """
+        all_metrics = []
+
+        # List of all metric properties
+        metric_properties = self._metric_types.split(",")
+
+        for prop_name in metric_properties:
+            metrics = getattr(self, prop_name)
+            if metrics:
+                all_metrics.extend(metrics)
+
+        return all_metrics or None
+
+    @property
+    def authors(self) -> Optional[list]:
+        """A list of namedtuples representing authors and their basic info
+        in the form `(id, name, uri)`.
+        """
+        out = []
+        Author = namedtuple('Author', 'id name uri')
+
+        # Handle both dict and direct access to results
+        if isinstance(self._json, dict):
+            results = self._json.get('results', [])
+        else:
+            results = []
+
+        for result in results:
+            author_data = result.get('author', {})
+            new = Author(
+                id=make_int_if_possible(author_data.get('id')),
+                name=author_data.get('name'),
+                uri=author_data.get('uri')
+            )
+            out.append(new)
+        return out or None
+
+    @property
+    def CitationCount(self) -> Optional[list]:
+        """Citation count metrics for each author.
+        Returns list of MetricData namedtuples with unified structure:
+        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        """
+        return extract_metric_data(self._json, 'CitationCount', self._by_year)
+
+    @property
+    def CitationsPerPublication(self) -> Optional[list]:
+        """Citations per publication metrics for each author.
+        Returns list of MetricData namedtuples with unified structure:
+        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        """
+        return extract_metric_data(self._json, 'CitationsPerPublication', self._by_year)
+
+    @property
+    def CitedPublications(self) -> Optional[list]:
+        """Cited publications metrics for each author.
+        Returns list of MetricData namedtuples with unified structure:
+        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        """
+        return extract_metric_data(self._json, 'CitedPublications', self._by_year)
+
+    @property
+    def Collaboration(self) -> Optional[list]:
+        """Collaboration metrics for each author.
+        Returns list of MetricData namedtuples with unified structure:
+        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        """
+        return extract_metric_data(self._json, 'Collaboration', self._by_year)
+
+    @property
+    def CollaborationImpact(self) -> Optional[list]:
+        """Collaboration impact metrics for each author.
+        Returns list of MetricData namedtuples with unified structure:
+        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        """
+        return extract_metric_data(self._json, 'CollaborationImpact', self._by_year)
+
+    @property
+    def FieldWeightedCitationImpact(self) -> Optional[list]:
+        """Field weighted citation impact metrics for each author.
+        Returns list of MetricData namedtuples with unified structure:
+        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        """
+        return extract_metric_data(self._json, 'FieldWeightedCitationImpact', self._by_year)
+
+    @property
+    def HIndices(self) -> Optional[list]:
+        """H-indices metrics for each author (only available when by_year=False).
+        Returns list of MetricData namedtuples with unified structure:
+        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        """
+        return extract_metric_data(self._json, 'HIndices', self._by_year)
+
+    @property
+    def OutputsInTopCitationPercentiles(self) -> Optional[list]:
+        """Outputs in top citation percentiles metrics for each author.
+        Returns list of MetricData namedtuples with unified structure:
+        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        """
+        return extract_metric_data(self._json, 'OutputsInTopCitationPercentiles', self._by_year)
+
+    @property
+    def PublicationsInTopJournalPercentiles(self) -> Optional[list]:
+        """Publications in top journal percentiles metrics for each author.
+        Returns list of MetricData namedtuples with unified structure:
+        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        """
+        return extract_metric_data(self._json, 'PublicationsInTopJournalPercentiles', self._by_year)
+
+    @property
+    def ScholarlyOutput(self) -> Optional[list]:
+        """Scholarly output metrics for each author.
+        Returns list of MetricData namedtuples with unified structure:
+        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        """
+        return extract_metric_data(self._json, 'ScholarlyOutput', self._by_year)
+
+    def __init__(self,
+                 author_ids: Union[str, list],
+                 metric_types: Optional[Union[str, list]] = None,
+                 by_year: bool = False,
+                 refresh: Union[bool, int] = False,
+                 **kwds: str
+                 ) -> None:
+        """Interaction with the SciVal Author Metrics API.
+
+        :param author_ids: Scopus Author ID(s). Can be a single ID or comma-separated 
+                           string of IDs, or a list of IDs (e.g. `[55586732900, 57215631099]`).
+        :param metric_types: Metric type(s) to retrieve. Can be a single metric 
+                             or comma-separated string, or a list. Available metrics are:
+                             AcademicCorporateCollaboration, AcademicCorporateCollaborationImpact,
+                             CitationCount, CitedPublications, Collaboration, CollaborationImpact,
+                             FieldWeightedCitationImpact, ScholarlyOutput,
+                             PublicationsInTopJournalPercentiles, OutputsInTopCitationPercentiles,
+                             HIndices.
+                             If not provided, all metrics are retrieved.
+        :param by_year: Whether to retrieve metrics broken down by year.
+        :param refresh: Whether to refresh the cached file if it exists or not.
+                        If int is passed, cached file will be refreshed if the
+                        number of days since last modification exceeds that value.
+        :param kwds: Keywords passed on as query parameters.  Must contain
+                     fields and values mentioned in the API specification at
+                     https://dev.elsevier.com/documentation/SciValAuthorAPI.wadl.
+            
+        Note:
+            All metric properties return lists of MetricData namedtuples with 
+            unified structure: `(author_id, author_name, metric, metric_type, 
+            year, value, percentage, threshold)`. Use the `all_metrics` property
+            to get all metrics concatenated into a single list for easy data
+            manipulation and analysis.
+        """
+        self._view = ''
+        self._refresh = refresh
+        self._by_year = by_year
+
+        # Handle authors parameter
+        if isinstance(author_ids, list):
+            author_ids = ",".join(str(a) for a in author_ids)
+
+        # Handle metric_types parameter - use all metrics by default
+        if metric_types is None:
+            if not by_year:
+                metric_types = SCIVAL_METRICS["AuthorMetrics"]["byYear"] + SCIVAL_METRICS["AuthorMetrics"]["notByYear"]
+            if by_year:
+                metric_types = SCIVAL_METRICS["AuthorMetrics"]["byYear"]
+
+        if isinstance(metric_types, list):
+            metric_types = ",".join(metric_types)
+
+        self._metric_types = metric_types
+
+        # Set up parameters for the API call
+        params = {
+            'authors': author_ids,
+            'metricTypes': metric_types,
+            'byYear': str(by_year).lower(),
+            **kwds
+        }
+
+        Retrieval.__init__(self, **params, **kwds)
+
+    def __str__(self):
+        """Return pretty text version of the author metrics."""
+        authors = self.authors or []
+        author_count = len(authors)
+
+        if author_count == 0:
+            return "No authors found"
+        else:
+            s = f"AuthorMetrics for {author_count} author(s):"
+            for author in authors:
+                s += f"\n- {author.name} (ID: {author.id})"
+            return s

--- a/pybliometrics/scival/author_metrics.py
+++ b/pybliometrics/scival/author_metrics.py
@@ -10,7 +10,7 @@ class AuthorMetrics(Retrieval):
     @property  
     def AcademicCorporateCollaboration(self) -> Optional[list[MetricData]]:
         """Academic corporate collaboration metrics for each author.
-        Returns list of MetricData namedtuples with unified structure:
+        Returns list of MetricData namedtuples with structure:
         (entity_id, entity_name, metric, year, value, percentage, threshold)
         """
         return extract_metric_data(self._json, 'AcademicCorporateCollaboration', self._by_year, "author")

--- a/pybliometrics/scival/author_metrics.py
+++ b/pybliometrics/scival/author_metrics.py
@@ -12,33 +12,34 @@ class AuthorMetrics(Retrieval):
     def AcademicCorporateCollaboration(self) -> Optional[list]:
         """Academic corporate collaboration metrics for each author.
         Returns list of MetricData namedtuples with unified structure:
-        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
         """
-        return extract_metric_data(self._json, 'AcademicCorporateCollaboration', self._by_year)
+        return extract_metric_data(self._json, 'AcademicCorporateCollaboration', self._by_year, "author")
 
     @property
     def AcademicCorporateCollaborationImpact(self) -> Optional[list]:
         """Academic corporate collaboration impact metrics for each author.
         Returns list of MetricData namedtuples with unified structure:
-        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
         """
-        return extract_metric_data(self._json, 'AcademicCorporateCollaborationImpact', self._by_year)
+        return extract_metric_data(self._json, 'AcademicCorporateCollaborationImpact', self._by_year, "author")
 
     @property
     def all_metrics(self) -> Optional[list]:
         """Get all available metrics concatenated into a single list.
         Returns list of MetricData namedtuples with unified structure:
-        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
         """
         all_metrics = []
 
         # List of all metric properties
-        metric_properties = self._metric_types.split(",")
-
-        for prop_name in metric_properties:
-            metrics = getattr(self, prop_name)
-            if metrics:
-                all_metrics.extend(metrics)
+        if self._metric_types:
+            metric_properties = self._metric_types.split(",")
+            
+            for prop_name in metric_properties:
+                metrics = getattr(self, prop_name)
+                if metrics:
+                    all_metrics.extend(metrics)
 
         return all_metrics or None
 
@@ -70,81 +71,81 @@ class AuthorMetrics(Retrieval):
     def CitationCount(self) -> Optional[list]:
         """Citation count metrics for each author.
         Returns list of MetricData namedtuples with unified structure:
-        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
         """
-        return extract_metric_data(self._json, 'CitationCount', self._by_year)
+        return extract_metric_data(self._json, 'CitationCount', self._by_year, "author")
 
     @property
     def CitationsPerPublication(self) -> Optional[list]:
         """Citations per publication metrics for each author.
         Returns list of MetricData namedtuples with unified structure:
-        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
         """
-        return extract_metric_data(self._json, 'CitationsPerPublication', self._by_year)
+        return extract_metric_data(self._json, 'CitationsPerPublication', self._by_year, "author")
 
     @property
     def CitedPublications(self) -> Optional[list]:
         """Cited publications metrics for each author.
         Returns list of MetricData namedtuples with unified structure:
-        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
         """
-        return extract_metric_data(self._json, 'CitedPublications', self._by_year)
+        return extract_metric_data(self._json, 'CitedPublications', self._by_year, "author")
 
     @property
     def Collaboration(self) -> Optional[list]:
         """Collaboration metrics for each author.
         Returns list of MetricData namedtuples with unified structure:
-        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
         """
-        return extract_metric_data(self._json, 'Collaboration', self._by_year)
+        return extract_metric_data(self._json, 'Collaboration', self._by_year, "author")
 
     @property
     def CollaborationImpact(self) -> Optional[list]:
         """Collaboration impact metrics for each author.
         Returns list of MetricData namedtuples with unified structure:
-        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
         """
-        return extract_metric_data(self._json, 'CollaborationImpact', self._by_year)
+        return extract_metric_data(self._json, 'CollaborationImpact', self._by_year, "author")
 
     @property
     def FieldWeightedCitationImpact(self) -> Optional[list]:
         """Field weighted citation impact metrics for each author.
         Returns list of MetricData namedtuples with unified structure:
-        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
         """
-        return extract_metric_data(self._json, 'FieldWeightedCitationImpact', self._by_year)
+        return extract_metric_data(self._json, 'FieldWeightedCitationImpact', self._by_year, "author")
 
     @property
     def HIndices(self) -> Optional[list]:
         """H-indices metrics for each author (only available when by_year=False).
         Returns list of MetricData namedtuples with unified structure:
-        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
         """
-        return extract_metric_data(self._json, 'HIndices', self._by_year)
+        return extract_metric_data(self._json, 'HIndices', self._by_year, "author")
 
     @property
     def OutputsInTopCitationPercentiles(self) -> Optional[list]:
         """Outputs in top citation percentiles metrics for each author.
         Returns list of MetricData namedtuples with unified structure:
-        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
         """
-        return extract_metric_data(self._json, 'OutputsInTopCitationPercentiles', self._by_year)
+        return extract_metric_data(self._json, 'OutputsInTopCitationPercentiles', self._by_year, "author")
 
     @property
     def PublicationsInTopJournalPercentiles(self) -> Optional[list]:
         """Publications in top journal percentiles metrics for each author.
         Returns list of MetricData namedtuples with unified structure:
-        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
         """
-        return extract_metric_data(self._json, 'PublicationsInTopJournalPercentiles', self._by_year)
+        return extract_metric_data(self._json, 'PublicationsInTopJournalPercentiles', self._by_year, "author")
 
     @property
     def ScholarlyOutput(self) -> Optional[list]:
         """Scholarly output metrics for each author.
         Returns list of MetricData namedtuples with unified structure:
-        (author_id, author_name, metric, metric_type, year, value, percentage, threshold)
+        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
         """
-        return extract_metric_data(self._json, 'ScholarlyOutput', self._by_year)
+        return extract_metric_data(self._json, 'ScholarlyOutput', self._by_year, "author")
 
     def __init__(self,
                  author_ids: Union[str, list],
@@ -175,7 +176,7 @@ class AuthorMetrics(Retrieval):
             
         Note:
             All metric properties return lists of MetricData namedtuples with 
-            unified structure: `(author_id, author_name, metric, metric_type, 
+            unified structure: `(entity_id, entity_name, metric, metric_type, 
             year, value, percentage, threshold)`. Use the `all_metrics` property
             to get all metrics concatenated into a single list for easy data
             manipulation and analysis.

--- a/pybliometrics/scival/author_metrics.py
+++ b/pybliometrics/scival/author_metrics.py
@@ -25,25 +25,6 @@ class AuthorMetrics(Retrieval):
         return extract_metric_data(self._json, 'AcademicCorporateCollaborationImpact', self._by_year, "author")
 
     @property
-    def all_metrics(self) -> Optional[list]:
-        """Get all available metrics concatenated into a single list.
-        Returns list of MetricData namedtuples with unified structure:
-        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
-        """
-        all_metrics = []
-
-        # List of all metric properties
-        if self._metric_types:
-            metric_properties = self._metric_types.split(",")
-            
-            for prop_name in metric_properties:
-                metrics = getattr(self, prop_name)
-                if metrics:
-                    all_metrics.extend(metrics)
-
-        return all_metrics or None
-
-    @property
     def authors(self) -> Optional[list]:
         """A list of namedtuples representing authors and their basic info
         in the form `(id, name, uri)`.
@@ -177,9 +158,8 @@ class AuthorMetrics(Retrieval):
         Note:
             All metric properties return lists of MetricData namedtuples with 
             unified structure: `(entity_id, entity_name, metric, metric_type, 
-            year, value, percentage, threshold)`. Use the `all_metrics` property
-            to get all metrics concatenated into a single list for easy data
-            manipulation and analysis.
+            year, value, percentage, threshold)` which enable concatenation
+            of results from different metrics.
         """
         self._view = ''
         self._refresh = refresh

--- a/pybliometrics/scival/author_metrics.py
+++ b/pybliometrics/scival/author_metrics.py
@@ -209,7 +209,7 @@ class AuthorMetrics(Retrieval):
             **kwds
         }
 
-        Retrieval.__init__(self, **params, **kwds)
+        Retrieval.__init__(self, **params)
 
     def __str__(self):
         """Return pretty text version of the author metrics."""

--- a/pybliometrics/scival/author_metrics.py
+++ b/pybliometrics/scival/author_metrics.py
@@ -4,28 +4,27 @@ from typing import Union, Optional
 from pybliometrics.superclasses import Retrieval
 from pybliometrics.utils import make_int_if_possible
 from pybliometrics.utils.constants import SCIVAL_METRICS
-from pybliometrics.utils.parse_metrics import extract_metric_data
-
+from pybliometrics.utils.parse_metrics import extract_metric_data, MetricData
 
 class AuthorMetrics(Retrieval):
     @property  
-    def AcademicCorporateCollaboration(self) -> Optional[list]:
+    def AcademicCorporateCollaboration(self) -> Optional[list[MetricData]]:
         """Academic corporate collaboration metrics for each author.
         Returns list of MetricData namedtuples with unified structure:
-        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
+        (entity_id, entity_name, metric, year, value, percentage, threshold)
         """
         return extract_metric_data(self._json, 'AcademicCorporateCollaboration', self._by_year, "author")
 
     @property
-    def AcademicCorporateCollaborationImpact(self) -> Optional[list]:
+    def AcademicCorporateCollaborationImpact(self) -> Optional[list[MetricData]]:
         """Academic corporate collaboration impact metrics for each author.
-        Returns list of MetricData namedtuples with unified structure:
-        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
+        Returns list of MetricData namedtuples with structure:
+        (entity_id, entity_name, metric, year, value, percentage, threshold)
         """
         return extract_metric_data(self._json, 'AcademicCorporateCollaborationImpact', self._by_year, "author")
 
     @property
-    def authors(self) -> Optional[list]:
+    def authors(self) -> Optional[list[MetricData]]:
         """A list of namedtuples representing authors and their basic info
         in the form `(id, name, uri)`.
         """
@@ -49,82 +48,82 @@ class AuthorMetrics(Retrieval):
         return out or None
 
     @property
-    def CitationCount(self) -> Optional[list]:
+    def CitationCount(self) -> Optional[list[MetricData]]:
         """Citation count metrics for each author.
-        Returns list of MetricData namedtuples with unified structure:
-        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
+        Returns list of MetricData namedtuples with structure:
+        (entity_id, entity_name, metric, year, value, percentage, threshold)
         """
         return extract_metric_data(self._json, 'CitationCount', self._by_year, "author")
 
     @property
-    def CitationsPerPublication(self) -> Optional[list]:
+    def CitationsPerPublication(self) -> Optional[list[MetricData]]:
         """Citations per publication metrics for each author.
-        Returns list of MetricData namedtuples with unified structure:
-        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
+        Returns list of MetricData namedtuples with structure:
+        (entity_id, entity_name, metric, year, value, percentage, threshold)
         """
         return extract_metric_data(self._json, 'CitationsPerPublication', self._by_year, "author")
 
     @property
-    def CitedPublications(self) -> Optional[list]:
+    def CitedPublications(self) -> Optional[list[MetricData]]:
         """Cited publications metrics for each author.
-        Returns list of MetricData namedtuples with unified structure:
-        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
+        Returns list of MetricData namedtuples with structure:
+        (entity_id, entity_name, metric, year, value, percentage, threshold)
         """
         return extract_metric_data(self._json, 'CitedPublications', self._by_year, "author")
 
     @property
-    def Collaboration(self) -> Optional[list]:
+    def Collaboration(self) -> Optional[list[MetricData]]:
         """Collaboration metrics for each author.
-        Returns list of MetricData namedtuples with unified structure:
-        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
+        Returns list of MetricData namedtuples with structure:
+        (entity_id, entity_name, metric, year, value, percentage, threshold)
         """
         return extract_metric_data(self._json, 'Collaboration', self._by_year, "author")
 
     @property
-    def CollaborationImpact(self) -> Optional[list]:
+    def CollaborationImpact(self) -> Optional[list[MetricData]]:
         """Collaboration impact metrics for each author.
-        Returns list of MetricData namedtuples with unified structure:
-        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
+        Returns list of MetricData namedtuples with structure:
+        (entity_id, entity_name, metric, year, value, percentage, threshold)
         """
         return extract_metric_data(self._json, 'CollaborationImpact', self._by_year, "author")
 
     @property
-    def FieldWeightedCitationImpact(self) -> Optional[list]:
+    def FieldWeightedCitationImpact(self) -> Optional[list[MetricData]]:
         """Field weighted citation impact metrics for each author.
-        Returns list of MetricData namedtuples with unified structure:
-        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
+        Returns list of MetricData namedtuples with structure:
+        (entity_id, entity_name, metric, year, value, percentage, threshold)
         """
         return extract_metric_data(self._json, 'FieldWeightedCitationImpact', self._by_year, "author")
 
     @property
-    def HIndices(self) -> Optional[list]:
+    def HIndices(self) -> Optional[list[MetricData]]:
         """H-indices metrics for each author (only available when by_year=False).
-        Returns list of MetricData namedtuples with unified structure:
-        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
+        Returns list of MetricData namedtuples with structure:
+        (entity_id, entity_name, metric, year, value, percentage, threshold)
         """
         return extract_metric_data(self._json, 'HIndices', self._by_year, "author")
 
     @property
-    def OutputsInTopCitationPercentiles(self) -> Optional[list]:
+    def OutputsInTopCitationPercentiles(self) -> Optional[list[MetricData]]:
         """Outputs in top citation percentiles metrics for each author.
-        Returns list of MetricData namedtuples with unified structure:
-        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
+        Returns list of MetricData namedtuples with structure:
+        (entity_id, entity_name, metric, year, value, percentage, threshold)
         """
         return extract_metric_data(self._json, 'OutputsInTopCitationPercentiles', self._by_year, "author")
 
     @property
-    def PublicationsInTopJournalPercentiles(self) -> Optional[list]:
+    def PublicationsInTopJournalPercentiles(self) -> Optional[list[MetricData]]:
         """Publications in top journal percentiles metrics for each author.
-        Returns list of MetricData namedtuples with unified structure:
-        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
+        Returns list of MetricData namedtuples with structure:
+        (entity_id, entity_name, metric, year, value, percentage, threshold)
         """
         return extract_metric_data(self._json, 'PublicationsInTopJournalPercentiles', self._by_year, "author")
 
     @property
-    def ScholarlyOutput(self) -> Optional[list]:
+    def ScholarlyOutput(self) -> Optional[list[MetricData]]:
         """Scholarly output metrics for each author.
-        Returns list of MetricData namedtuples with unified structure:
-        (entity_id, entity_name, metric, metric_type, year, value, percentage, threshold)
+        Returns list of MetricData namedtuples with structure:
+        (entity_id, entity_name, metric, year, value, percentage, threshold)
         """
         return extract_metric_data(self._json, 'ScholarlyOutput', self._by_year, "author")
 
@@ -157,7 +156,7 @@ class AuthorMetrics(Retrieval):
             
         Note:
             All metric properties return lists of MetricData namedtuples with 
-            unified structure: `(entity_id, entity_name, metric, metric_type, 
+            structure: `(entity_id, entity_name, metric, 
             year, value, percentage, threshold)` which enable concatenation
             of results from different metrics.
         """

--- a/pybliometrics/scival/tests/test_AuthorMetrics.py
+++ b/pybliometrics/scival/tests/test_AuthorMetrics.py
@@ -43,8 +43,8 @@ def test_all_metrics():
     assert len(single_author_all_metrics) == 29
     expected_first_metric = MetricData(entity_id=6602819806,
                                        entity_name='Algül, Hana',
-                                       metric='AcademicCorporateCollaboration',
-                                       metric_type='Academic-corporate collaboration',
+                                       metric='Academic-corporate collaboration',
+                                       metric_type='AcademicCorporateCollaboration',
                                        year='all',
                                        value=12,
                                        percentage=22.64151,
@@ -56,8 +56,8 @@ def test_all_metrics():
     assert len(single_author_h_index_all_metrics) == 1
     expected_h_index = MetricData(entity_id=6602819806,
                                   entity_name='Algül, Hana',
-                                  metric='HIndices',
-                                  metric_type='h-index',
+                                  metric='h-index',
+                                  metric_type='HIndices',
                                   year='all', value=46.0,
                                   percentage=None,
                                   threshold=None)
@@ -68,8 +68,8 @@ def test_all_metrics():
     assert len(multiple_authors_all_metrics) == 280
     expected_multi_metric = MetricData(entity_id=6603480302,
                                        entity_name='Vogel-Heuser, Birgit',
-                                       metric='AcademicCorporateCollaboration',
-                                       metric_type='Academic-corporate collaboration',
+                                       metric='Academic-corporate collaboration',
+                                       metric_type='AcademicCorporateCollaboration',
                                        year='2024',
                                        value=8,
                                        percentage=21.052631,

--- a/pybliometrics/scival/tests/test_AuthorMetrics.py
+++ b/pybliometrics/scival/tests/test_AuthorMetrics.py
@@ -1,0 +1,251 @@
+from collections import namedtuple
+
+from pybliometrics.scival.author_metrics import AuthorMetrics
+from pybliometrics.utils.startup import init
+
+init()
+
+# Test cases as specified
+single_author_all = AuthorMetrics("6602819806", by_year=False, refresh=30)
+single_author_h_index = AuthorMetrics("6602819806", metric_types=["HIndices"], by_year=False, refresh=30)
+multiple_authors_all = AuthorMetrics([7201667143, 6603480302], by_year=True, refresh=30)
+empty_metrics = AuthorMetrics("0000000000")
+
+
+def test_academic_corporate_collaboration():
+    """Test AcademicCorporateCollaboration property for all test cases."""
+    result = single_author_all.AcademicCorporateCollaboration
+
+    assert has_all_fields(result[0])
+    assert single_author_h_index.AcademicCorporateCollaboration is None
+
+    result_multi = multiple_authors_all.AcademicCorporateCollaboration
+    assert has_all_fields(result_multi[0])
+
+
+def test_academic_corporate_collaboration_impact():
+    """Test AcademicCorporateCollaborationImpact property for all test cases."""
+    result = single_author_all.AcademicCorporateCollaborationImpact
+    assert has_all_fields(result[0])
+    assert single_author_h_index.AcademicCorporateCollaborationImpact is None
+
+    result_multi = multiple_authors_all.AcademicCorporateCollaborationImpact
+    assert has_all_fields(result_multi[0])
+
+
+def test_all_metrics():
+    """Test all_metrics property for all test cases."""
+    MetricData = namedtuple('MetricData',
+                            'author_id author_name metric metric_type year value percentage threshold',
+                            defaults=(None, None, None, None, "all", None, None, None))
+
+    single_author_all_metrics = single_author_all.all_metrics
+    assert len(single_author_all_metrics) == 29
+    expected_first_metric = MetricData(author_id=6602819806,
+                                       author_name='Algül, Hana',
+                                       metric='AcademicCorporateCollaboration',
+                                       metric_type='Academic-corporate collaboration',
+                                       year='all',
+                                       value=12,
+                                       percentage=22.64151,
+                                       threshold=None)
+    assert expected_first_metric == single_author_all_metrics[0]
+
+
+    single_author_h_index_all_metrics = single_author_h_index.all_metrics
+    assert len(single_author_h_index_all_metrics) == 1
+    expected_h_index = MetricData(author_id=6602819806,
+                                  author_name='Algül, Hana',
+                                  metric='HIndices',
+                                  metric_type='h-index',
+                                  year='all', value=46.0,
+                                  percentage=None,
+                                  threshold=None)
+    assert expected_h_index == single_author_h_index_all_metrics[0]
+
+
+    multiple_authors_all_metrics = multiple_authors_all.all_metrics
+    assert len(multiple_authors_all_metrics) == 280
+    expected_multi_metric = MetricData(author_id=6603480302,
+                                       author_name='Vogel-Heuser, Birgit',
+                                       metric='AcademicCorporateCollaboration',
+                                       metric_type='Academic-corporate collaboration',
+                                       year='2024',
+                                       value=8,
+                                       percentage=21.052631,
+                                       threshold=None)
+    assert expected_multi_metric == multiple_authors_all_metrics[10]
+
+
+def test_authors():
+    """Test the authors property for all test cases with actual values."""
+    # Test single author with all metrics
+    authors = single_author_all.authors
+    assert len(authors) == 1
+    assert authors[0].id == 6602819806
+    assert authors[0].name == "Algül, Hana"
+    assert authors[0].uri == "Author/6602819806"
+
+    # Test single author with H-indices only
+    authors_h = single_author_h_index.authors
+    assert len(authors_h) == 1
+    assert authors_h[0].id == 6602819806
+    assert authors_h[0].name == "Algül, Hana"
+    assert authors_h[0].uri == "Author/6602819806"
+
+    # Test multiple authors with actual names and IDs
+    authors_multi = multiple_authors_all.authors
+    assert len(authors_multi) == 2
+
+    # Sort by ID and test
+    authors_sorted = sorted(authors_multi, key=lambda x: x.id)
+
+    assert authors_sorted[0].id == 6603480302
+    assert authors_sorted[0].name == "Vogel-Heuser, Birgit"
+    assert authors_sorted[0].uri == "Author/6603480302"
+
+    assert authors_sorted[1].id == 7201667143
+    assert authors_sorted[1].name == "Wolff, Klaus Dietrich"
+    assert authors_sorted[1].uri == "Author/7201667143"
+
+
+def has_all_fields(metric_data):
+    """Check if the metric data has all required fields."""
+    required_fields = ['author_id', 'author_name', 'metric', 'metric_type', 'year', 'value', 'percentage', 'threshold']
+    return all(hasattr(metric_data, field) for field in required_fields)
+
+
+def test_citation_count():
+    """Test CitationCount property for all test cases."""
+    result = single_author_all.CitationCount
+    assert has_all_fields(result[0])
+    assert single_author_h_index.CitationCount is None
+
+    result_multi = multiple_authors_all.CitationCount
+    assert has_all_fields(result_multi[0])
+
+
+def test_citations_per_publication():
+    """Test CitationsPerPublication property for all test cases."""
+    result = single_author_all.CitationsPerPublication
+    assert has_all_fields(result[0])
+    assert single_author_h_index.CitationsPerPublication is None
+
+    result_multi = multiple_authors_all.CitationsPerPublication
+    assert has_all_fields(result_multi[0])
+
+
+def test_cited_publications():
+    """Test CitedPublications property for all test cases."""
+    result = single_author_all.CitedPublications
+    assert has_all_fields(result[0])
+    assert single_author_h_index.CitedPublications is None
+
+    result_multi = multiple_authors_all.CitedPublications
+    assert has_all_fields(result_multi[0])
+
+
+def test_collaboration():
+    """Test Collaboration property for all test cases."""
+    result = single_author_all.Collaboration
+    assert has_all_fields(result[0])
+    assert single_author_h_index.Collaboration is None
+
+    result_multi = multiple_authors_all.Collaboration
+    assert has_all_fields(result_multi[0])
+
+
+def test_collaboration_impact():
+    """Test CollaborationImpact property for all test cases."""
+    result = single_author_all.CollaborationImpact
+    assert has_all_fields(result[0])
+    assert single_author_h_index.CollaborationImpact is None
+
+    result_multi = multiple_authors_all.CollaborationImpact
+    assert has_all_fields(result_multi[0])
+
+
+def test_empty_metrics():
+    """Test handling of empty metric_types."""
+    assert empty_metrics.all_metrics is None
+    assert empty_metrics.authors is None 
+    assert empty_metrics.CitationCount is None
+    assert empty_metrics.CitationsPerPublication is None
+    assert empty_metrics.CitedPublications is None
+    assert empty_metrics.Collaboration is None
+    assert empty_metrics.CollaborationImpact is None
+
+
+def test_field_weighted_citation_impact():
+    """Test FieldWeightedCitationImpact property for all test cases."""
+    result = single_author_all.FieldWeightedCitationImpact
+    assert has_all_fields(result[0])
+    assert single_author_h_index.FieldWeightedCitationImpact is None
+
+    result_multi = multiple_authors_all.FieldWeightedCitationImpact
+    assert has_all_fields(result_multi[0])
+
+
+def test_h_indices():
+    """Test HIndices property for all test cases."""
+    result = single_author_all.HIndices
+    assert has_all_fields(result[0])
+
+    result_h = single_author_h_index.HIndices
+    assert has_all_fields(result_h[0])
+
+    # HIndices are not available by year
+    assert multiple_authors_all.HIndices is None
+
+
+def test_outputs_in_top_citation_percentiles():
+    """Test OutputsInTopCitationPercentiles property for all test cases."""
+    result = single_author_all.OutputsInTopCitationPercentiles
+    assert has_all_fields(result[0])
+    assert single_author_h_index.OutputsInTopCitationPercentiles is None
+
+    result_multi = multiple_authors_all.OutputsInTopCitationPercentiles
+    assert has_all_fields(result_multi[0])
+
+
+def test_publications_in_top_journal_percentiles():
+    """Test PublicationsInTopJournalPercentiles property for all test cases."""
+    result = single_author_all.PublicationsInTopJournalPercentiles
+    assert has_all_fields(result[0])
+    assert single_author_h_index.PublicationsInTopJournalPercentiles is None
+
+    result_multi = multiple_authors_all.PublicationsInTopJournalPercentiles
+    assert has_all_fields(result_multi[0])
+
+
+def test_scholarly_output():
+    """Test ScholarlyOutput property for all test cases."""
+    result = single_author_all.ScholarlyOutput
+    assert has_all_fields(result[0])
+    assert single_author_h_index.ScholarlyOutput is None
+
+    result_multi = multiple_authors_all.ScholarlyOutput
+    assert has_all_fields(result_multi[0])
+
+
+def test_str_representation():
+    """Test the string representation of AuthorMetrics objects using actual results."""
+    # Test single author with all metrics
+    str_single = str(single_author_all)
+    expected_single = "AuthorMetrics for 1 author(s):\n- Algül, Hana (ID: 6602819806)"
+    assert str_single == expected_single
+
+    # Test single author with H-indices only
+    str_h_index = str(single_author_h_index)
+    expected_h_index = "AuthorMetrics for 1 author(s):\n- Algül, Hana (ID: 6602819806)"
+    assert str_h_index == expected_h_index
+
+    # Test multiple authors
+    str_multiple = str(multiple_authors_all)
+    expected_multiple = "AuthorMetrics for 2 author(s):\n- Wolff, Klaus Dietrich (ID: 7201667143)\n- Vogel-Heuser, Birgit (ID: 6603480302)"
+    assert str_multiple == expected_multiple
+
+    # Test empty metrics
+    str_empty = str(empty_metrics)
+    expected_empty = "No authors found"
+    assert str_empty == expected_empty

--- a/pybliometrics/scival/tests/test_AuthorMetrics.py
+++ b/pybliometrics/scival/tests/test_AuthorMetrics.py
@@ -11,6 +11,10 @@ single_author_h_index = AuthorMetrics("6602819806", metric_types=["HIndices"], b
 multiple_authors_all = AuthorMetrics([7201667143, 6603480302], by_year=True, refresh=30)
 empty_metrics = AuthorMetrics("0000000000")
 
+MetricData = namedtuple('MetricData', 
+                       'entity_id entity_name metric metric_type year value percentage threshold',
+                       defaults=(None, None, None, None, "all", None, None, None))
+
 
 def test_academic_corporate_collaboration():
     """Test AcademicCorporateCollaboration property for all test cases."""
@@ -18,9 +22,25 @@ def test_academic_corporate_collaboration():
 
     assert has_all_fields(result[0])
     assert single_author_h_index.AcademicCorporateCollaboration is None
+    assert result[0].entity_id == 6602819806
+    assert result[0].entity_name == 'Algül, Hana'
+    assert result[0].metric == 'Academic-corporate collaboration'
+    assert result[0].metric_type == 'AcademicCorporateCollaboration'
+    assert result[0].year == 'all'
+    assert result[0].value >= 12
+    assert result[0].percentage >= 22
+    assert result[0].threshold is None
 
     result_multi = multiple_authors_all.AcademicCorporateCollaboration
     assert has_all_fields(result_multi[0])
+    assert result_multi[0].entity_id == 7201667143
+    assert result_multi[0].entity_name == 'Wolff, Klaus Dietrich'
+    assert result_multi[0].metric == 'Academic-corporate collaboration'
+    assert result_multi[0].metric_type == 'AcademicCorporateCollaboration'
+    assert result_multi[0].year >= '2024'
+    assert result_multi[0].value >= 0
+    assert result_multi[0].percentage >= 0
+    assert result_multi[0].threshold is None
 
 
 def test_academic_corporate_collaboration_impact():
@@ -31,50 +51,6 @@ def test_academic_corporate_collaboration_impact():
 
     result_multi = multiple_authors_all.AcademicCorporateCollaborationImpact
     assert has_all_fields(result_multi[0])
-
-
-def test_all_metrics():
-    """Test all_metrics property for all test cases."""
-    MetricData = namedtuple('MetricData',
-                            'entity_id entity_name metric metric_type year value percentage threshold',
-                            defaults=(None, None, None, None, "all", None, None, None))
-
-    single_author_all_metrics = single_author_all.all_metrics
-    assert len(single_author_all_metrics) == 29
-    expected_first_metric = MetricData(entity_id=6602819806,
-                                       entity_name='Algül, Hana',
-                                       metric='Academic-corporate collaboration',
-                                       metric_type='AcademicCorporateCollaboration',
-                                       year='all',
-                                       value=12,
-                                       percentage=22.64151,
-                                       threshold=None)
-    assert expected_first_metric == single_author_all_metrics[0]
-
-
-    single_author_h_index_all_metrics = single_author_h_index.all_metrics
-    assert len(single_author_h_index_all_metrics) == 1
-    expected_h_index = MetricData(entity_id=6602819806,
-                                  entity_name='Algül, Hana',
-                                  metric='h-index',
-                                  metric_type='HIndices',
-                                  year='all', value=46.0,
-                                  percentage=None,
-                                  threshold=None)
-    assert expected_h_index == single_author_h_index_all_metrics[0]
-
-
-    multiple_authors_all_metrics = multiple_authors_all.all_metrics
-    assert len(multiple_authors_all_metrics) == 280
-    expected_multi_metric = MetricData(entity_id=6603480302,
-                                       entity_name='Vogel-Heuser, Birgit',
-                                       metric='Academic-corporate collaboration',
-                                       metric_type='AcademicCorporateCollaboration',
-                                       year='2024',
-                                       value=8,
-                                       percentage=21.052631,
-                                       threshold=None)
-    assert expected_multi_metric == multiple_authors_all_metrics[10]
 
 
 def test_authors():
@@ -167,7 +143,6 @@ def test_collaboration_impact():
 
 def test_empty_metrics():
     """Test handling of empty metric_types."""
-    assert empty_metrics.all_metrics is None
     assert empty_metrics.authors is None 
     assert empty_metrics.CitationCount is None
     assert empty_metrics.CitationsPerPublication is None

--- a/pybliometrics/scival/tests/test_AuthorMetrics.py
+++ b/pybliometrics/scival/tests/test_AuthorMetrics.py
@@ -36,13 +36,13 @@ def test_academic_corporate_collaboration_impact():
 def test_all_metrics():
     """Test all_metrics property for all test cases."""
     MetricData = namedtuple('MetricData',
-                            'author_id author_name metric metric_type year value percentage threshold',
+                            'entity_id entity_name metric metric_type year value percentage threshold',
                             defaults=(None, None, None, None, "all", None, None, None))
 
     single_author_all_metrics = single_author_all.all_metrics
     assert len(single_author_all_metrics) == 29
-    expected_first_metric = MetricData(author_id=6602819806,
-                                       author_name='Algül, Hana',
+    expected_first_metric = MetricData(entity_id=6602819806,
+                                       entity_name='Algül, Hana',
                                        metric='AcademicCorporateCollaboration',
                                        metric_type='Academic-corporate collaboration',
                                        year='all',
@@ -54,8 +54,8 @@ def test_all_metrics():
 
     single_author_h_index_all_metrics = single_author_h_index.all_metrics
     assert len(single_author_h_index_all_metrics) == 1
-    expected_h_index = MetricData(author_id=6602819806,
-                                  author_name='Algül, Hana',
+    expected_h_index = MetricData(entity_id=6602819806,
+                                  entity_name='Algül, Hana',
                                   metric='HIndices',
                                   metric_type='h-index',
                                   year='all', value=46.0,
@@ -66,8 +66,8 @@ def test_all_metrics():
 
     multiple_authors_all_metrics = multiple_authors_all.all_metrics
     assert len(multiple_authors_all_metrics) == 280
-    expected_multi_metric = MetricData(author_id=6603480302,
-                                       author_name='Vogel-Heuser, Birgit',
+    expected_multi_metric = MetricData(entity_id=6603480302,
+                                       entity_name='Vogel-Heuser, Birgit',
                                        metric='AcademicCorporateCollaboration',
                                        metric_type='Academic-corporate collaboration',
                                        year='2024',
@@ -111,7 +111,7 @@ def test_authors():
 
 def has_all_fields(metric_data):
     """Check if the metric data has all required fields."""
-    required_fields = ['author_id', 'author_name', 'metric', 'metric_type', 'year', 'value', 'percentage', 'threshold']
+    required_fields = ['entity_id', 'entity_name', 'metric', 'metric_type', 'year', 'value', 'percentage', 'threshold']
     return all(hasattr(metric_data, field) for field in required_fields)
 
 

--- a/pybliometrics/scival/tests/test_AuthorMetrics.py
+++ b/pybliometrics/scival/tests/test_AuthorMetrics.py
@@ -12,8 +12,8 @@ multiple_authors_all = AuthorMetrics([7201667143, 6603480302], by_year=True, ref
 empty_metrics = AuthorMetrics("0000000000")
 
 MetricData = namedtuple('MetricData', 
-                       'entity_id entity_name metric metric_type year value percentage threshold',
-                       defaults=(None, None, None, None, "all", None, None, None))
+                       'entity_id entity_name metric year value percentage threshold',
+                       defaults=(None, None, None, "all", None, None, None))
 
 
 def test_academic_corporate_collaboration():
@@ -25,7 +25,6 @@ def test_academic_corporate_collaboration():
     assert result[0].entity_id == 6602819806
     assert result[0].entity_name == 'Algül, Hana'
     assert result[0].metric == 'Academic-corporate collaboration'
-    assert result[0].metric_type == 'AcademicCorporateCollaboration'
     assert result[0].year == 'all'
     assert result[0].value >= 12
     assert result[0].percentage >= 22
@@ -36,7 +35,6 @@ def test_academic_corporate_collaboration():
     assert result_multi[0].entity_id == 7201667143
     assert result_multi[0].entity_name == 'Wolff, Klaus Dietrich'
     assert result_multi[0].metric == 'Academic-corporate collaboration'
-    assert result_multi[0].metric_type == 'AcademicCorporateCollaboration'
     assert result_multi[0].year >= '2024'
     assert result_multi[0].value >= 0
     assert result_multi[0].percentage >= 0
@@ -87,7 +85,7 @@ def test_authors():
 
 def has_all_fields(metric_data):
     """Check if the metric data has all required fields."""
-    required_fields = ['entity_id', 'entity_name', 'metric', 'metric_type', 'year', 'value', 'percentage', 'threshold']
+    required_fields = ['entity_id', 'entity_name', 'metric', 'year', 'value', 'percentage', 'threshold']
     return all(hasattr(metric_data, field) for field in required_fields)
 
 

--- a/pybliometrics/superclasses/retrieval.py
+++ b/pybliometrics/superclasses/retrieval.py
@@ -1,16 +1,17 @@
 """Superclass to access all Scopus retrieval APIs and dump the results."""
 
+import hashlib
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 
 from pybliometrics.superclasses import Base
-from pybliometrics.utils import APIS_WITH_ID_TYPE, get_config, URLS
+from pybliometrics.utils import APIS_NO_ID_IN_ULR, APIS_WITH_ID_TYPE, get_config, URLS
 
 
 class Retrieval(Base):
     def __init__(self,
-                 identifier: Union[int, str],
-                 id_type: str = None,
+                 identifier: Optional[Union[int, str]] = None,
+                 id_type: Optional[str] = None,
                  **kwds: str
                  ) -> None:
         """Class intended as superclass to perform retrievals.
@@ -38,9 +39,13 @@ class Retrieval(Base):
                 stem += "-" + self._citation
             if self._date:
                 stem += "-" + self._date
+        # For APIs that don't use ID in URL, hash the parameters for unique cache filename
+        elif api in APIS_NO_ID_IN_ULR:
+            params_str = str(sorted(kwds.items()))
+            stem = hashlib.md5(params_str.encode()).hexdigest()
         else:
-            url += identifier
-            stem = identifier.replace('/', '_')
+            url += str(identifier)
+            stem = str(identifier).replace('/', '_')
         # Get cache file path
         config = get_config()
         parent = Path(config.get('Directories', api))

--- a/pybliometrics/superclasses/retrieval.py
+++ b/pybliometrics/superclasses/retrieval.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 from pybliometrics.superclasses import Base
-from pybliometrics.utils import APIS_NO_ID_IN_ULR, APIS_WITH_ID_TYPE, get_config, URLS
+from pybliometrics.utils import APIS_NO_ID_IN_URL, APIS_WITH_ID_TYPE, get_config, URLS
 
 
 class Retrieval(Base):
@@ -40,7 +40,7 @@ class Retrieval(Base):
             if self._date:
                 stem += "-" + self._date
         # For APIs that don't use ID in URL, hash the parameters for unique cache filename
-        elif api in APIS_NO_ID_IN_ULR:
+        elif api in APIS_NO_ID_IN_URL:
             params_str = str(sorted(kwds.items()))
             stem = hashlib.md5(params_str.encode()).hexdigest()
         else:

--- a/pybliometrics/utils/__init__.py
+++ b/pybliometrics/utils/__init__.py
@@ -3,4 +3,5 @@ from pybliometrics.utils.constants import *
 from pybliometrics.utils.create_config import *
 from pybliometrics.utils.get_content import *
 from pybliometrics.utils.parse_content import *
+from pybliometrics.utils.parse_metrics import *
 from pybliometrics.utils.startup import *

--- a/pybliometrics/utils/constants.py
+++ b/pybliometrics/utils/constants.py
@@ -33,6 +33,7 @@ DEFAULT_PATHS = {
     'ObjectRetrieval': CACHE_PATH / "ScienceDirect" / 'object_retrieval',
     'PlumXMetrics': CACHE_PATH / "Scopus" / 'plumx',
     'PublicationLookup': CACHE_PATH / "Scival" / "publication_lookup",
+    'AuthorMetrics': CACHE_PATH / "Scival" / "author_metrics",
     'ScDirSubjectClassifications': CACHE_PATH / "ScienceDirect" / 'subject_classification',
     'ScienceDirectSearch': CACHE_PATH / "ScienceDirect" / 'science_direct_search',
     'ScopusSearch': CACHE_PATH / "Scopus" / 'scopus_search',
@@ -59,6 +60,7 @@ URLS = {
     'ObjectMetadata': RETRIEVAL_BASE + 'object/',
     'ObjectRetrieval': RETRIEVAL_BASE + 'object/',
     'PublicationLookup': SCIVAL_BASE + 'publication/',
+    'AuthorMetrics': SCIVAL_BASE + 'author/metrics/',
     'PlumXMetrics': 'https://api.elsevier.com/analytics/plumx/',
     'ScDirSubjectClassifications': RETRIEVAL_BASE + 'subject/scidir/',
     'ScienceDirectSearch': SEARCH_BASE + 'sciencedirect/',
@@ -91,6 +93,28 @@ VIEWS = {
     "ObjectRetrieval": [""]
 }
 
+# SciVal Metrics
+SCIVAL_METRICS = {
+    "AuthorMetrics": {
+        "byYear": [
+            "AcademicCorporateCollaboration",
+            "AcademicCorporateCollaborationImpact",
+            "Collaboration",
+            "CitationCount",
+            "CitationsPerPublication",
+            "CollaborationImpact",
+            "CitedPublications",
+            "FieldWeightedCitationImpact",
+            "ScholarlyOutput",
+            "PublicationsInTopJournalPercentiles",
+            "OutputsInTopCitationPercentiles"
+        ],
+        "notByYear": [
+            "HIndices"
+        ]
+    }
+}
+
 # APIs whose URL needs an id_type
 APIS_WITH_ID_TYPE = {"AbstractRetrieval",
                      "PlumXMetrics",
@@ -98,6 +122,9 @@ APIS_WITH_ID_TYPE = {"AbstractRetrieval",
                      "ArticleEntitlement",
                      "ObjectMetadata",
                      "ObjectRetrieval"}
+
+# APIs that do not require an ID in the URL
+APIS_NO_ID_IN_ULR = {"AuthorMetrics"}
 
 # Item per page limits for all classes
 COUNTS = {
@@ -119,6 +146,7 @@ RATELIMITS = {
     'ArticleEntitlement': 0,
     'ArticleMetadata': 6,
     'ArticleRetrieval': 10,
+    'AuthorMetrics': 6,
     'AuthorRetrieval': 3,
     'AuthorSearch': 2,
     'CitationOverview': 4,

--- a/pybliometrics/utils/constants.py
+++ b/pybliometrics/utils/constants.py
@@ -124,7 +124,7 @@ APIS_WITH_ID_TYPE = {"AbstractRetrieval",
                      "ObjectRetrieval"}
 
 # APIs that do not require an ID in the URL
-APIS_NO_ID_IN_ULR = {"AuthorMetrics"}
+APIS_NO_ID_IN_URL = {"AuthorMetrics"}
 
 # Item per page limits for all classes
 COUNTS = {

--- a/pybliometrics/utils/parse_metrics.py
+++ b/pybliometrics/utils/parse_metrics.py
@@ -1,0 +1,152 @@
+"""Utility functions to parse and extract metrics data from JSON responses."""
+from collections import namedtuple
+
+from pybliometrics.utils import make_int_if_possible
+
+# Global namedtuple for all metric data with default values
+MetricData = namedtuple('MetricData', 
+                       'author_id author_name metric metric_type year value percentage threshold',
+                       defaults=(None, None, None, None, "all", None, None, None))
+
+
+def extract_metric_data(json_data, metric_type: str, by_year: bool = False):
+    """Helper function to extract metric data for a specific metric type.
+    
+    Parameters
+    ----------
+    json_data : dict
+        The JSON response from the API
+    metric_type : str
+        The metric type to extract
+    by_year : bool, optional
+        Whether the data is broken down by year
+        
+    Returns
+    -------
+    list or None
+        List of MetricData namedtuples or None if no data found
+    """
+    out = []
+
+    # Get results from JSON data
+    if isinstance(json_data, dict):
+        results = json_data.get('results', [])
+    else:
+        results = []
+
+    for result in results:
+        author_id, author_name = extract_author_info(result)
+        metric_data = find_metric_data(result, metric_type)
+
+        if not metric_data:
+            continue
+
+        # Process metric data using unified approach
+        metric_items = process_metric(metric_data, author_id, author_name, metric_type, by_year)
+        if metric_items:
+            out.extend(metric_items)
+
+    return out or None
+
+
+def extract_author_info(result: dict) -> tuple:
+    """Extract author ID and name from a result.
+    
+    Parameters
+    ----------
+    result : dict
+        Author result from API response
+        
+    Returns
+    -------
+    tuple
+        (author_id, author_name)
+    """
+    author_data = result.get('author', {})
+    author_id = make_int_if_possible(author_data.get('id'))
+    author_name = author_data.get('name')
+    return author_id, author_name
+
+
+def find_metric_data(result: dict, metric_type: str):
+    """Find specific metric data in the metrics list.
+    
+    Parameters
+    ----------
+    result : dict
+        Author result from API response
+    metric_type : str
+        The metric type to find
+        
+    Returns
+    -------
+    dict or None
+        The metric data or None if not found
+    """
+    metrics = result.get('metrics', [])
+    for metric in metrics:
+        if metric.get('metricType') == metric_type:
+            return metric
+    return None
+
+
+def process_metric(metric_data: dict, author_id: int, author_name: str, metric_type: str, by_year: bool = False):
+    """Unified function to process all metric types.
+    
+    Parameters
+    ----------
+    metric_data : dict
+        The metric data from API response
+    author_id : int
+        Author ID
+    author_name : str
+        Author name
+    metric_type : str
+        The metric type
+    by_year : bool, optional
+        Whether the data is broken down by year
+        
+    Returns
+    -------
+    list or None
+        List of MetricData namedtuples or None if no data
+    """
+    out = []
+
+    # Normalize all metrics to have a 'values' structure
+    if 'values' in metric_data:
+        # Already has multiple values (collaboration/threshold metrics)
+        values_list = metric_data['values']
+    else:
+        # Simple metric - wrap in a list to make it uniform
+        values_list = [metric_data]
+
+    # Process all value items uniformly
+    for value_item in values_list:
+        # Extract type-specific information - just try to get them, default to None
+        collab_type = value_item.get('collabType')
+        threshold = value_item.get('threshold')
+
+        # Normalize data structure: convert single values to year-keyed dictionaries
+        if by_year:
+            value_data = value_item.get('valueByYear', {})
+            percentage_data = value_item.get('percentageByYear', {})
+        else:
+            value_data = {"all": value_item.get('value')}
+            percentage_data = {"all": value_item.get('percentage')}
+
+        # Process all years uniformly
+        for year in value_data.keys():
+            new = MetricData(
+                author_id=author_id,
+                author_name=author_name,
+                metric=metric_type,
+                metric_type=collab_type or value_item.get('indexType') or value_item.get('impactType'),
+                year=str(year),
+                value=value_data.get(year),
+                percentage=percentage_data.get(year),
+                threshold=threshold
+            )
+            out.append(new)
+
+    return out if out else None

--- a/pybliometrics/utils/parse_metrics.py
+++ b/pybliometrics/utils/parse_metrics.py
@@ -5,8 +5,8 @@ from pybliometrics.utils import make_int_if_possible
 
 # Global namedtuple for all metric data with default values
 MetricData = namedtuple('MetricData', 
-                       'entity_id entity_name metric metric_type year value percentage threshold',
-                       defaults=(None, None, None, None, "all", None, None, None))
+                       'entity_id entity_name metric year value percentage threshold',
+                       defaults=(None, None, None, "all", None, None, None))
 
 
 def extract_metric_data(json_data, metric_type: str, by_year: bool, entity_type: str):
@@ -149,7 +149,6 @@ def process_metric(metric_data: dict, entity_id: int, entity_name: str, metric_t
                 entity_id=entity_id,
                 entity_name=entity_name,
                 metric=metric_name,
-                metric_type=metric_type,
                 year=str(year),
                 value=value_data.get(year),
                 percentage=percentage_data.get(year),

--- a/pybliometrics/utils/parse_metrics.py
+++ b/pybliometrics/utils/parse_metrics.py
@@ -141,11 +141,15 @@ def process_metric(metric_data: dict, entity_id: int, entity_name: str, metric_t
 
         # Process all years uniformly
         for year in value_data.keys():
+            # For nested metrics (like Collaboration), metric is the specific type (collabType)
+            # For simple metrics (like CitationCount), metric is the metric_type itself
+            metric_name = collab_type or value_item.get('indexType') or value_item.get('impactType') or metric_type
+
             new = MetricData(
                 entity_id=entity_id,
                 entity_name=entity_name,
-                metric=metric_type,
-                metric_type=collab_type or value_item.get('indexType') or value_item.get('impactType'),
+                metric=metric_name,
+                metric_type=metric_type,
                 year=str(year),
                 value=value_data.get(year),
                 percentage=percentage_data.get(year),


### PR DESCRIPTION
This PR implements the `metrics` endpoint of the [AuthorLookup API](https://dev.elsevier.com/documentation/SciValAuthorAPI.wadl). Since the `lookup` endpoint does not have any relevant information I propose only to implement this endpoint.