### PR TITLE
`AbtractRetrieval.contributor_group()`: Standardise format of contributors and parse

### DIFF
--- a/pybliometrics/scopus/abstract_retrieval.py
+++ b/pybliometrics/scopus/abstract_retrieval.py
@@ -310,15 +310,16 @@ class AbstractRetrieval(Retrieval):
         items = listify(chained_get(self._head, path, []))
         out = []
         for item in items:
-            entry = item.get('contributor', {})
-            new = Contributor(
-                given_name=entry.get('ce:given-name'),
-                initials=entry.get('ce:initials'),
-                surname=entry.get('ce:surname'),
-                indexed_name=entry.get('ce:indexed-name'),
-                role=entry.get('@role')
-            )
-            out.append(new)
+            entries = listify(item.get('contributor', {}))
+            for entry in entries:
+                new = Contributor(
+                    given_name=entry.get('ce:given-name'),
+                    initials=entry.get('ce:initials'),
+                    surname=entry.get('ce:surname'),
+                    indexed_name=entry.get('ce:indexed-name'),
+                    role=entry.get('@role')
+                )
+                out.append(new)
         return out or None
 
     @property

--- a/pybliometrics/scopus/tests/test_AbstractRetrieval.py
+++ b/pybliometrics/scopus/tests/test_AbstractRetrieval.py
@@ -32,6 +32,8 @@ ar10 = AbstractRetrieval('10.1109/Multi-Temp.2019.8866947', view='ENTITLED', ref
 ab11 = AbstractRetrieval('2-s2.0-85160105660', view="REF", refresh=30)
 # FULL view with list of collaborations
 ab12 = AbstractRetrieval('2-s2.0-85044008512', view='FULL', refresh=30)
+# List of contributors in contributor group
+ab13 = AbstractRetrieval("2-s2.0-85038825012", view="FULL", refresh=30)
 
 
 def test_abstract():
@@ -167,6 +169,11 @@ def test_contributor_group():
     assert expected in received
     assert ab3.contributor_group is None
     assert ab8.contributor_group is None
+
+    expected_13 = Contributor(given_name='Constantinos', initials='C.', surname='Antoniou',
+                    indexed_name='Antoniou C.', role='edit')
+    assert len(ab13.contributor_group) == 4
+    assert ab13.contributor_group[0] == expected_13
 
 
 def test_copyright():


### PR DESCRIPTION
Fix for #422