### PR TITLE
#425 Handle `None` in Organisation

### DIFF
--- a/pybliometrics/scopus/abstract_retrieval.py
+++ b/pybliometrics/scopus/abstract_retrieval.py
@@ -349,7 +349,7 @@ class AbstractRetrieval(Retrieval):
                 try:
                     org = org['$']
                 except TypeError:  # Multiple names given
-                    org = "; ".join([d['$'] for d in org])
+                    org = "; ".join([d['$'] for d in org if d])
             except KeyError:
                 org = None
             new = Correspondence(surname=item.get('person', {}).get('ce:surname'),


### PR DESCRIPTION
This PR handles cases where organisations have a `None` in the list:
```py
[None,
 {'$': 'Department of Neurosurgery'},
 {'$': 'Renji Hospital'},
 {'$': 'School of Medicine'},
 {'$': 'Shanghai Jiao Tong University'}]
```